### PR TITLE
Add mobile home screen and layout

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,20 +1,5 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { AppNavigator } from "./src/navigation/AppNavigator";
 
 export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
-  );
+  return <AppNavigator />;
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~55.0.8",
+        "expo-linear-gradient": "~55.0.9",
         "expo-status-bar": "~55.0.4",
         "react": "19.2.0",
         "react-native": "0.83.2"
@@ -3361,6 +3362,17 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.9.tgz",
+      "integrity": "sha512-S82iF+CVoSBVHdwusLQGh6Th/kcWLHU47jZhBPwyTrYWnsHZtb0oCqU96YvhDYvhbTdsuOaKEi+Xu+r/I2R8ow==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "expo": "~55.0.8",
+    "expo-linear-gradient": "~55.0.9",
     "expo-status-bar": "~55.0.4",
     "react": "19.2.0",
     "react-native": "0.83.2"

--- a/apps/mobile/src/components/Header.tsx
+++ b/apps/mobile/src/components/Header.tsx
@@ -1,0 +1,178 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { theme } from "../styles/theme";
+
+type HeaderProps = {
+  title?: string;
+  subtitle?: string;
+  tagline?: string;
+  onAlertPress?: () => void;
+};
+
+export function Header({
+  title = "WayPoint",
+  subtitle = "Welcome back, Hailey",
+  tagline = "Journey Smart, Journey Safe",
+  onAlertPress,
+}: HeaderProps) {
+  const [taglineTop, taglineBottom] = tagline.split(",").map((part) => part.trim());
+
+  return (
+    <LinearGradient
+      colors={[theme.colors.ink, theme.colors.inkSoft, theme.colors.brand]}
+      locations={[0, 0.42, 1]}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      style={styles.shell}
+    >
+      <View style={styles.coolWash} />
+      <View style={styles.centerWash} />
+      <View style={styles.warmWash} />
+      <View style={styles.orangeGlow} />
+      <View style={styles.orangeOrb} />
+      <View style={styles.content}>
+        <View style={styles.copy}>
+          <Text style={styles.title} adjustsFontSizeToFit numberOfLines={1}>
+            {title}
+          </Text>
+          <View style={styles.taglineWrap}>
+            <Text style={styles.tagline}>{taglineTop || "Journey Smart"}</Text>
+            <Text style={styles.tagline}>{taglineBottom || "Journey Safe"}</Text>
+          </View>
+          <Text style={styles.subtitle}>{subtitle}</Text>
+        </View>
+        <Pressable
+          style={styles.alertButton}
+          accessibilityRole="button"
+          onPress={onAlertPress}
+        >
+          <Text style={styles.alertIcon}>◠</Text>
+          <View style={styles.alertDot} />
+        </Pressable>
+      </View>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  shell: {
+    borderRadius: theme.radius.lg,
+    overflow: "hidden",
+    borderBottomLeftRadius: 28,
+    borderBottomRightRadius: 28,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 8,
+  },
+  orangeGlow: {
+    position: "absolute",
+    right: -16,
+    top: -26,
+    width: 172,
+    height: 172,
+    borderRadius: 999,
+    backgroundColor: theme.colors.headerGlow,
+  },
+  orangeOrb: {
+    position: "absolute",
+    right: -26,
+    top: -24,
+    width: 118,
+    height: 118,
+    borderRadius: 999,
+    backgroundColor: theme.colors.headerOrb,
+  },
+  coolWash: {
+    position: "absolute",
+    left: -54,
+    top: -30,
+    bottom: 0,
+    width: 250,
+    borderRadius: 999,
+    backgroundColor: theme.colors.headerCoolWash,
+  },
+  centerWash: {
+    position: "absolute",
+    left: "30%",
+    top: -28,
+    width: 190,
+    height: 190,
+    borderRadius: 999,
+    backgroundColor: theme.colors.headerCenterWash,
+  },
+  warmWash: {
+    position: "absolute",
+    right: -34,
+    top: -56,
+    width: 238,
+    height: 238,
+    borderRadius: 999,
+    backgroundColor: theme.colors.headerWarmWash,
+  },
+  content: {
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 22,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "transparent",
+    gap: 12,
+  },
+  copy: {
+    flex: 1,
+    minWidth: 0,
+    paddingRight: 14,
+  },
+  taglineWrap: {
+    marginTop: 8,
+    alignItems: "flex-start",
+    gap: 2,
+  },
+  title: {
+    fontSize: 34,
+    lineHeight: 34,
+    fontWeight: "900",
+    color: theme.colors.white,
+    letterSpacing: -1.2,
+  },
+  subtitle: {
+    marginTop: 10,
+    fontSize: 14,
+    color: "rgba(255,255,255,0.78)",
+  },
+  tagline: {
+    fontSize: 8,
+    fontWeight: "800",
+    letterSpacing: 2,
+    textTransform: "uppercase",
+    color: "rgba(255,255,255,0.92)",
+    textAlign: "left",
+  },
+  alertButton: {
+    width: 50,
+    height: 50,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "rgba(255,255,255,0.12)",
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.14)",
+    position: "relative",
+  },
+  alertIcon: {
+    color: theme.colors.white,
+    fontSize: 22,
+  },
+  alertDot: {
+    position: "absolute",
+    top: 11,
+    right: 11,
+    width: 10,
+    height: 10,
+    borderRadius: 999,
+    backgroundColor: theme.colors.brand,
+  },
+});

--- a/apps/mobile/src/components/NavBar.tsx
+++ b/apps/mobile/src/components/NavBar.tsx
@@ -1,0 +1,184 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { AppScreen, theme } from "../styles/theme";
+
+const navItems = [
+  { key: "routes", label: "Routes", icon: "□" },
+  { key: "stats", label: "Stats", icon: "◇" },
+  { key: "profile", label: "Profile", icon: "○" },
+  { key: "settings", label: "Settings", icon: "⋯" },
+] as const;
+
+type NavBarProps = {
+  activeScreen: AppScreen;
+  onNavigate: (screen: AppScreen) => void;
+};
+
+export function NavBar({ activeScreen, onNavigate }: NavBarProps) {
+  const isJourneyScreen = activeScreen === "startJourney";
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.bar}>
+        <View style={styles.sideGroup}>
+          {navItems.slice(0, 2).map((item) => (
+            <Pressable
+              key={item.key}
+              style={styles.navItem}
+              onPress={() => onNavigate(item.key)}
+            >
+              <Text style={[styles.navIcon, activeScreen === item.key && styles.navIconActive]}>
+                {item.icon}
+              </Text>
+              <Text style={[styles.navLabel, activeScreen === item.key && styles.navLabelActive]}>
+                {item.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <View style={styles.centerWrap}>
+          <Pressable
+            style={styles.centerButtonShell}
+            onPress={() => onNavigate(isJourneyScreen ? "home" : "startJourney")}
+          >
+            <LinearGradient
+              colors={[theme.colors.brandBright, theme.colors.brand]}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={styles.centerButton}
+            >
+              <View style={styles.centerInnerRing} />
+              <Text style={styles.centerIcon}>{isJourneyScreen ? "✓" : "➤"}</Text>
+            </LinearGradient>
+          </Pressable>
+          <Text style={styles.centerLabelTop}>
+            {isJourneyScreen ? "Complete" : "Start"}
+          </Text>
+          <Text style={styles.centerLabelBottom}>Journey</Text>
+        </View>
+
+        <View style={styles.sideGroup}>
+          {navItems.slice(2).map((item) => (
+            <Pressable
+              key={item.key}
+              style={styles.navItem}
+              onPress={() => onNavigate(item.key)}
+            >
+              <Text style={[styles.navIcon, activeScreen === item.key && styles.navIconActive]}>
+                {item.icon}
+              </Text>
+              <Text style={[styles.navLabel, activeScreen === item.key && styles.navLabelActive]}>
+                {item.label}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: "absolute",
+    left: 18,
+    right: 18,
+    bottom: 8,
+  },
+  bar: {
+    borderTopLeftRadius: theme.radius.pill,
+    borderTopRightRadius: theme.radius.pill,
+    borderBottomLeftRadius: theme.radius.pill,
+    borderBottomRightRadius: theme.radius.pill,
+    backgroundColor: "#778093",
+    paddingHorizontal: 28,
+    paddingTop: 12,
+    paddingBottom: 18,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    shadowColor: theme.colors.ink,
+    shadowOpacity: 0.16,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 12,
+  },
+  sideGroup: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-evenly",
+  },
+  navItem: {
+    minWidth: 58,
+    alignItems: "center",
+    gap: 3,
+  },
+  navIcon: {
+    color: "rgba(255,255,255,0.92)",
+    fontSize: 22,
+  },
+  navLabel: {
+    color: "rgba(255,255,255,0.94)",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  navIconActive: {
+    color: theme.colors.white,
+  },
+  navLabelActive: {
+    color: theme.colors.white,
+    fontWeight: "700",
+  },
+  centerWrap: {
+    marginTop: -30,
+    alignItems: "center",
+  },
+  centerButtonShell: {
+    width: 68,
+    height: 68,
+    borderRadius: 999,
+    borderWidth: 4,
+    borderColor: "rgba(255,250,247,0.92)",
+    overflow: "hidden",
+    shadowColor: theme.colors.brand,
+    shadowOpacity: 0.34,
+    shadowRadius: 22,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 14,
+  },
+  centerButton: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    position: "relative",
+  },
+  centerInnerRing: {
+    position: "absolute",
+    inset: 4,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.14)",
+  },
+  centerIcon: {
+    color: theme.colors.white,
+    fontSize: 26,
+    fontWeight: "700",
+  },
+  centerLabelTop: {
+    marginTop: 7,
+    fontSize: 8,
+    fontWeight: "700",
+    letterSpacing: 2.4,
+    textTransform: "uppercase",
+    color: "rgba(255,255,255,0.9)",
+  },
+  centerLabelBottom: {
+    marginTop: 2,
+    fontSize: 8,
+    fontWeight: "700",
+    letterSpacing: 2.4,
+    textTransform: "uppercase",
+    color: "rgba(255,255,255,0.9)",
+  },
+});

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -1,0 +1,31 @@
+import { StatusBar } from "expo-status-bar";
+import { SafeAreaView, StyleSheet, View } from "react-native";
+import { NavBar } from "../components/NavBar";
+import { HomeScreen } from "../screens/HomeScreen";
+import { theme } from "../styles/theme";
+
+export function AppNavigator() {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar style="dark" />
+      <View style={styles.container}>
+        <HomeScreen
+          onOpenSavedRoutes={() => {}}
+          onOpenPopularRoutes={() => {}}
+          onOpenAlerts={() => {}}
+        />
+        <NavBar activeScreen="home" onNavigate={() => {}} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  container: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,628 @@
+import { Image, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { Header } from "../components/Header";
+import { theme } from "../styles/theme";
+
+type JourneyMode = "idle" | "active" | "off_route" | "complete";
+
+type HomeScreenProps = {
+  onOpenSavedRoutes: () => void;
+  onOpenPopularRoutes: () => void;
+  onOpenAlerts: () => void;
+};
+
+const mockHeroMode: JourneyMode = "idle";
+
+const heroStateByMode: Record<
+  JourneyMode,
+  {
+    statusText: string;
+    statusDotColor: string;
+    locationLabel: string;
+    locationValue: string;
+    weatherValue: string;
+    weatherText: string;
+    showRoute: boolean;
+    routeOpacity: number;
+  }
+> = {
+  idle: {
+    statusText: "Ready to find a journey",
+    statusDotColor: theme.colors.success,
+    locationLabel: "Current Location",
+    locationValue: "Downtown Area",
+    weatherValue: "72°F",
+    weatherText: "Sunny",
+    showRoute: false,
+    routeOpacity: 0,
+  },
+  active: {
+    statusText: "Current journey",
+    statusDotColor: theme.colors.success,
+    locationLabel: "Current Journey",
+    locationValue: "Riverwalk Loop",
+    weatherValue: "72°F",
+    weatherText: "Sunny",
+    showRoute: true,
+    routeOpacity: 1,
+  },
+  off_route: {
+    statusText: "Deviated from route",
+    statusDotColor: theme.colors.brand,
+    locationLabel: "Current Location",
+    locationValue: "Near Pine Street",
+    weatherValue: "71°F",
+    weatherText: "Cloudy",
+    showRoute: true,
+    routeOpacity: 1,
+  },
+  complete: {
+    statusText: "Journey complete",
+    statusDotColor: theme.colors.brandBright,
+    locationLabel: "Current Location",
+    locationValue: "Downtown Area",
+    weatherValue: "70°F",
+    weatherText: "Clear",
+    showRoute: true,
+    routeOpacity: 0.45,
+  },
+};
+
+export function HomeScreen({
+  onOpenSavedRoutes,
+  onOpenPopularRoutes,
+  onOpenAlerts,
+}: HomeScreenProps) {
+  const heroState = heroStateByMode[mockHeroMode];
+
+  return (
+    <LinearGradient
+      colors={[theme.colors.background, theme.colors.backgroundAlt, theme.colors.backgroundDeep]}
+      locations={[0, 0.48, 1]}
+      start={{ x: 0.5, y: 0 }}
+      end={{ x: 0.5, y: 1 }}
+      style={styles.screen}
+    >
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Header onAlertPress={onOpenAlerts} />
+
+        <View style={styles.heroShell}>
+          <View style={styles.hero}>
+            <View style={styles.skyBlob} />
+            <View style={styles.grassBlob} />
+            <View style={styles.grassBlobTwo} />
+            {heroState.showRoute ? (
+              <>
+                <View style={[styles.routeLinePrimary, { opacity: heroState.routeOpacity }]} />
+                <View style={[styles.routeNodeLeft, { opacity: heroState.routeOpacity }]} />
+                <View style={[styles.routeNodeRight, { opacity: heroState.routeOpacity }]} />
+              </>
+            ) : null}
+            <View style={styles.pinWrap}>
+              <View style={styles.pinCircleOuter}>
+                <View style={styles.pinCircleInner} />
+              </View>
+              <View style={styles.pinTail} />
+            </View>
+            <View style={styles.waveOne} />
+            <View style={styles.waveTwo} />
+            <View style={styles.waveThree} />
+            <View style={styles.mapCard} />
+
+            <View style={styles.statusCard}>
+              <View style={styles.statusRow}>
+                <View style={[styles.statusDot, { backgroundColor: heroState.statusDotColor }]} />
+                <View>
+                  <Text style={styles.statusLabel}>Status</Text>
+                  <Text style={styles.statusValue}>{heroState.statusText}</Text>
+                </View>
+              </View>
+            </View>
+
+            <View style={styles.locationCard}>
+              <View>
+                <Text style={styles.locationLabel}>{heroState.locationLabel}</Text>
+                <Text style={styles.locationValue}>{heroState.locationValue}</Text>
+              </View>
+              <View style={styles.weatherWrap}>
+                <Text style={styles.weatherLabel}>Weather</Text>
+                <Text style={styles.weatherValue}>{heroState.weatherValue}</Text>
+                <Text style={styles.weatherText}>{heroState.weatherText}</Text>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.routeGrid}>
+          <LinearGradient
+            colors={[theme.colors.inkSoft, "#A8B27F", "#DF9059"]}
+            locations={[0, 0.28, 1]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[styles.routeCard, styles.savedCard]}
+          >
+            <View style={styles.routeSavedWash} />
+            <View style={styles.routeSavedWarmWash} />
+            <View style={styles.routeOrb} />
+            <View style={styles.routeOrbSaved} />
+            <Text style={styles.routeTitle}>Saved Routes</Text>
+            <Text style={styles.routeSubtitle}>12 favorites</Text>
+            <Pressable onPress={onOpenSavedRoutes} style={({ pressed }) => pressed && styles.routePressablePressed}>
+              {({ pressed }) => (
+                <View style={[styles.routeActionPill, pressed && styles.routeActionPillPressed]}>
+                  <Text style={styles.routeAction}>View all →</Text>
+                </View>
+              )}
+            </Pressable>
+          </LinearGradient>
+          <LinearGradient
+            colors={[theme.colors.accentPeach, "#EA9358", "#D27645"]}
+            locations={[0, 0.58, 1]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[styles.routeCard, styles.popularCard]}
+          >
+            <View style={styles.routePopularWarmWash} />
+            <View style={styles.routeOrb} />
+            <Text style={styles.routeTitle}>Popular Routes</Text>
+            <Text style={styles.routeSubtitle}>Trending now</Text>
+            <Pressable onPress={onOpenPopularRoutes} style={({ pressed }) => pressed && styles.routePressablePressed}>
+              {({ pressed }) => (
+                <View style={[styles.routeActionPill, pressed && styles.routeActionPillPressed]}>
+                  <Text style={styles.routeAction}>Explore →</Text>
+                </View>
+              )}
+            </Pressable>
+          </LinearGradient>
+        </View>
+
+        <View style={styles.analyticsShell}>
+          <Text style={styles.analyticsEyebrow}>Your progress</Text>
+          <Text style={styles.analyticsTitle}>Daily analytics</Text>
+
+          <View style={styles.analyticsGrid}>
+            {[
+              ["Steps", "8.2k"],
+              ["Streak", "14d"],
+              ["Distance", "6.4 mi"],
+              ["Individual Routes", "16"],
+              ["Group Routes", "7"],
+            ].map(([label, value]) => (
+              <Pressable
+                key={label}
+                style={({ pressed }) => [styles.analyticsPressable, pressed && styles.analyticsPressablePressed]}
+              >
+                {({ pressed }) => (
+                  <LinearGradient
+                    colors={["#E8CBB7", "#F4DED0", "#FFF8F3"]}
+                    locations={[0, 0.45, 1]}
+                    start={{ x: 0.5, y: 0 }}
+                    end={{ x: 0.5, y: 1 }}
+                    style={[styles.analyticsCard, pressed && styles.analyticsCardPressed]}
+                  >
+                    <Text style={styles.analyticsLabel}>{label}</Text>
+                    <Text style={styles.analyticsValue}>{value}</Text>
+                  </LinearGradient>
+                )}
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    paddingHorizontal: 18,
+    paddingTop: 18,
+    paddingBottom: 180,
+    gap: 18,
+  },
+  heroShell: {
+    borderRadius: 32,
+    overflow: "hidden",
+    backgroundColor: theme.colors.heroSky,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.16,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 12 },
+    elevation: 10,
+  },
+  hero: {
+    minHeight: 540,
+    overflow: "hidden",
+    borderRadius: 32,
+    backgroundColor: theme.colors.heroSkySoft,
+  },
+  skyBlob: {
+    position: "absolute",
+    right: -24,
+    top: -18,
+    width: 240,
+    height: 240,
+    borderRadius: 120,
+    backgroundColor: theme.colors.heroSky,
+  },
+  grassBlob: {
+    position: "absolute",
+    left: -32,
+    bottom: 102,
+    width: 320,
+    height: 180,
+    borderRadius: 100,
+    backgroundColor: theme.colors.heroGrass,
+    transform: [{ rotate: "-10deg" }],
+  },
+  grassBlobTwo: {
+    position: "absolute",
+    left: -20,
+    bottom: -20,
+    width: 300,
+    height: 180,
+    borderRadius: 100,
+    backgroundColor: theme.colors.heroGrassDeep,
+    opacity: 0.6,
+  },
+  routeLinePrimary: {
+    position: "absolute",
+    left: 118,
+    top: 258,
+    width: 220,
+    height: 12,
+    borderRadius: 999,
+    backgroundColor: "#6D73F1",
+    transform: [{ rotate: "15deg" }],
+  },
+  routeNodeLeft: {
+    position: "absolute",
+    left: 96,
+    top: 286,
+    width: 30,
+    height: 30,
+    borderRadius: 999,
+    backgroundColor: "#6D73F1",
+    borderWidth: 5,
+    borderColor: "rgba(255,255,255,0.9)",
+  },
+  routeNodeRight: {
+    position: "absolute",
+    right: 92,
+    top: 308,
+    width: 30,
+    height: 30,
+    borderRadius: 999,
+    backgroundColor: "#6D73F1",
+    borderWidth: 5,
+    borderColor: "rgba(255,255,255,0.9)",
+  },
+  pinWrap: {
+    position: "absolute",
+    left: "50%",
+    top: 206,
+    marginLeft: -44,
+    alignItems: "center",
+  },
+  pinCircleOuter: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    backgroundColor: "#675EF2",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  pinCircleInner: {
+    width: 28,
+    height: 28,
+    borderRadius: 999,
+    backgroundColor: theme.colors.white,
+    borderWidth: 8,
+    borderColor: "#675EF2",
+  },
+  pinTail: {
+    marginTop: -4,
+    width: 0,
+    height: 0,
+    borderLeftWidth: 28,
+    borderRightWidth: 28,
+    borderTopWidth: 34,
+    borderLeftColor: "transparent",
+    borderRightColor: "transparent",
+    borderTopColor: "#675EF2",
+  },
+  waveOne: {
+    position: "absolute",
+    left: -60,
+    top: 176,
+    width: 520,
+    height: 24,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.88)",
+    transform: [{ rotate: "9deg" }],
+  },
+  waveTwo: {
+    position: "absolute",
+    left: 70,
+    top: 46,
+    width: 360,
+    height: 18,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.8)",
+    transform: [{ rotate: "-8deg" }],
+  },
+  waveThree: {
+    position: "absolute",
+    left: 150,
+    bottom: 96,
+    width: 330,
+    height: 20,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.82)",
+    transform: [{ rotate: "-8deg" }],
+  },
+  mapCard: {
+    position: "absolute",
+    right: 58,
+    top: 108,
+    width: 80,
+    height: 44,
+    borderRadius: 14,
+    backgroundColor: "rgba(255,255,255,0.54)",
+  },
+  statusCard: {
+    margin: 20,
+    alignSelf: "flex-start",
+    borderRadius: 24,
+    backgroundColor: theme.colors.overlay,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    shadowColor: theme.colors.ink,
+    shadowOpacity: 0.08,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  statusDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 999,
+    backgroundColor: theme.colors.success,
+  },
+  statusLabel: {
+    fontSize: 12,
+    color: theme.colors.textMuted,
+  },
+  statusValue: {
+    marginTop: 3,
+    fontSize: 18,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  locationCard: {
+    position: "absolute",
+    left: 20,
+    right: 20,
+    bottom: 20,
+    borderRadius: 24,
+    backgroundColor: theme.colors.overlay,
+    paddingHorizontal: 16,
+    paddingVertical: 13,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    shadowColor: theme.colors.ink,
+    shadowOpacity: 0.08,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+  },
+  locationLabel: {
+    fontSize: 12,
+    color: theme.colors.textMuted,
+  },
+  locationValue: {
+    marginTop: 5,
+    fontSize: 20,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  weatherWrap: {
+    alignItems: "flex-end",
+  },
+  weatherLabel: {
+    fontSize: 10,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
+  },
+  weatherValue: {
+    marginTop: 5,
+    fontSize: 20,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  weatherText: {
+    marginTop: 3,
+    fontSize: 12,
+    color: theme.colors.textSoft,
+  },
+  routeGrid: {
+    gap: 14,
+  },
+  routeCard: {
+    position: "relative",
+    overflow: "hidden",
+    borderRadius: 30,
+    paddingHorizontal: 24,
+    paddingVertical: 24,
+    minHeight: 186,
+    justifyContent: "flex-end",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.2,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 6,
+  },
+  savedCard: {},
+  popularCard: {},
+  routePressablePressed: {
+    transform: [{ translateY: -1 }],
+  },
+  routeSavedWash: {
+    position: "absolute",
+    left: -68,
+    top: -8,
+    bottom: 0,
+    width: 250,
+    borderRadius: 999,
+    backgroundColor: theme.colors.savedTint,
+  },
+  routeSavedWarmWash: {
+    position: "absolute",
+    right: -74,
+    bottom: -70,
+    width: 310,
+    height: 310,
+    borderRadius: 999,
+    backgroundColor: theme.colors.savedWarmWash,
+  },
+  routeOrb: {
+    position: "absolute",
+    right: -58,
+    top: -54,
+    width: 205,
+    height: 205,
+    borderRadius: 999,
+    backgroundColor: theme.colors.popularOrb,
+  },
+  routeOrbSaved: {
+    position: "absolute",
+    left: 62,
+    bottom: -98,
+    width: 278,
+    height: 278,
+    borderRadius: 999,
+    backgroundColor: theme.colors.savedOrb,
+  },
+  routePopularWarmWash: {
+    position: "absolute",
+    left: -22,
+    bottom: -96,
+    width: 350,
+    height: 290,
+    borderRadius: 999,
+    backgroundColor: theme.colors.popularWarmWash,
+  },
+  routeTitle: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: theme.colors.white,
+  },
+  routeSubtitle: {
+    marginTop: 10,
+    fontSize: 18,
+    fontWeight: "600",
+    color: "rgba(255,255,255,0.88)",
+  },
+  routeAction: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: theme.colors.white,
+  },
+  routeActionPill: {
+    marginTop: 28,
+    alignSelf: "flex-start",
+    borderRadius: 999,
+    backgroundColor: "rgba(255,255,255,0.18)",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  routeActionPillPressed: {
+    backgroundColor: "rgba(255,255,255,0.28)",
+    transform: [{ scale: 1.03 }],
+  },
+  analyticsShell: {
+    borderRadius: 30,
+    backgroundColor: "#FFFCFA",
+    paddingHorizontal: 18,
+    paddingVertical: 18,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.08,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 4,
+  },
+  analyticsEyebrow: {
+    fontSize: 12,
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
+  },
+  analyticsTitle: {
+    marginTop: 8,
+    fontSize: 28,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  analyticsGrid: {
+    marginTop: 16,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+    justifyContent: "space-between",
+  },
+  analyticsPressable: {
+    width: "47.8%",
+  },
+  analyticsPressablePressed: {
+    transform: [{ translateY: -2 }],
+  },
+  analyticsCard: {
+    width: "100%",
+    borderRadius: 18,
+    borderWidth: 1,
+    borderColor: "rgba(202,116,73,0.14)",
+    paddingHorizontal: 14,
+    paddingVertical: 16,
+    alignItems: "center",
+    shadowColor: theme.colors.ink,
+    shadowOpacity: 0.12,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  analyticsCardPressed: {
+    transform: [{ scale: 1.03 }],
+    shadowOpacity: 0.12,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 5,
+  },
+  analyticsLabel: {
+    fontSize: 11,
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: "#7A6058",
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  analyticsValue: {
+    marginTop: 10,
+    fontSize: 26,
+    fontWeight: "800",
+    color: "#4B3E45",
+    textAlign: "center",
+  },
+});

--- a/apps/mobile/src/styles/theme.ts
+++ b/apps/mobile/src/styles/theme.ts
@@ -1,0 +1,65 @@
+export const theme = {
+  colors: {
+    background: "#F6EEE4",
+    backgroundAlt: "#F1E7DC",
+    backgroundDeep: "#EADFD2",
+    surface: "#FFFAF7",
+    surfaceSoft: "#F8ECE5",
+    surfaceTint: "#F1DDD1",
+    text: "#58505D",
+    textSoft: "#7F7076",
+    textMuted: "#97858D",
+    border: "#EADACF",
+    brand: "#DE8558",
+    brandBright: "#F1B078",
+    brandDeep: "#CA7449",
+    accentPeach: "#F0AE8D",
+    accentCoral: "#D97E4D",
+    accentLime: "#B8CF5C",
+    success: "#BFD65A",
+    ink: "#6B7486",
+    inkSoft: "#8B94A5",
+    headerGlow: "rgba(222,133,88,0.08)",
+    headerOrb: "rgba(241,176,120,0.1)",
+    headerCoolWash: "rgba(167,187,216,0.14)",
+    headerWarmWash: "rgba(223,133,88,0.12)",
+    headerCenterWash: "rgba(255,255,255,0.025)",
+    savedBase: "#A5AE83",
+    savedOrb: "rgba(236,183,98,0.16)",
+    savedTint: "rgba(180,203,132,0.18)",
+    savedWarmWash: "rgba(226,152,83,0.18)",
+    popularBase: "#E28A54",
+    popularOrb: "rgba(246,195,157,0.16)",
+    popularWarmWash: "rgba(255,189,136,0.18)",
+    heroSky: "#B7CDEB",
+    heroSkySoft: "#E7EFF8",
+    heroGrass: "#CFDFC1",
+    heroGrassDeep: "#B8CDAF",
+    overlay: "rgba(255,250,247,0.92)",
+    white: "#FFFFFF",
+  },
+  spacing: {
+    xs: 6,
+    sm: 10,
+    md: 16,
+    lg: 24,
+    xl: 32,
+  },
+  radius: {
+    sm: 14,
+    md: 22,
+    lg: 30,
+    pill: 999,
+  },
+};
+
+export type AppScreen =
+  | "home"
+  | "startJourney"
+  | "routes"
+  | "stats"
+  | "profile"
+  | "settings"
+  | "alerts";
+
+export type RouteSection = "saved" | "popular";


### PR DESCRIPTION
Summary
This PR adds the first mobile home screen implementation in the Expo app, including the app shell, home screen layout, shared theme tokens, and reusable header/navigation components.

What changed
added the mobile app entry wiring through [App.tsx](app://-/index.html#)
added the home screen UI in [HomeScreen.tsx](app://-/index.html#)
added shared mobile components in [Header.tsx](app://-/index.html#) and [NavBar.tsx](app://-/index.html#)
added mobile theme tokens in [theme.ts](app://-/index.html#)
added navigator wiring for the current home-screen-only flow in [AppNavigator.tsx](app://-/index.html#)
added expo-linear-gradient for the gradient-based UI treatment
Notes
this PR is intentionally limited to the home screen only
other screen files were left out to avoid overlap with parallel teammate work
navigation is currently scoped to the home screen to keep this branch isolated
Validation
ran npx tsc --noEmit
verified the Expo app runs with the restored gradient dependency