### PR TITLE
Feat/fs route screen

### DIFF
--- a/apps/mobile/src/components/NavBar.tsx
+++ b/apps/mobile/src/components/NavBar.tsx
@@ -30,27 +30,39 @@ export function NavBar({
 }: NavBarProps) {
   const isJourneyScreen = activeScreen === "startJourney";
   const isActiveJourneyScreen = activeScreen === "activeJourney";
+  const isRoutesScreen = activeScreen === "routes";
+  const showsHomeCenterButton =
+    isJourneyScreen || isActiveJourneyScreen || isRoutesScreen;
+  const usesGreenHomeButton = isRoutesScreen;
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   const centerTarget =
-    activeScreen === "activeJourney"
+    showsHomeCenterButton
       ? "home"
-      : activeScreen === "startJourney"
-        ? "activeJourney"
       : hasActiveJourney
         ? "activeJourney"
         : "startJourney";
 
-  const centerTopLabel = isActiveJourneyScreen
+  const centerTopLabel = showsHomeCenterButton
     ? "Home"
     : hasActiveJourney
       ? "Active"
       : "Start";
 
-  const centerBottomLabel = isActiveJourneyScreen ? "" : "Journey";
+  const centerBottomLabel = showsHomeCenterButton ? "" : "Journey";
+  const centerButtonColors = showsHomeCenterButton
+    ? usesGreenHomeButton
+      ? [centerGreen, centerGreen]
+      : [navPeach, navPeach]
+    : [centerGreen, centerGreen];
+  const centerButtonShadow = showsHomeCenterButton
+    ? usesGreenHomeButton
+      ? centerGreenDeep
+      : navPeach
+    : centerGreenDeep;
 
   useEffect(() => {
-    if (isJourneyScreen) {
+    if (!showsHomeCenterButton && !hasActiveJourney) {
       const pulse = Animated.loop(
         Animated.sequence([
           Animated.timing(pulseAnim, {
@@ -75,7 +87,7 @@ export function NavBar({
     }
 
     pulseAnim.setValue(1);
-  }, [isJourneyScreen, pulseAnim]);
+  }, [hasActiveJourney, pulseAnim, showsHomeCenterButton]);
 
   return (
     <View style={styles.wrapper}>
@@ -115,18 +127,21 @@ export function NavBar({
             ]}
           >
             <Pressable
-              style={styles.centerButtonShell}
+              style={[
+                styles.centerButtonShell,
+                { shadowColor: centerButtonShadow },
+              ]}
               onPress={() => onNavigate(centerTarget)}
             >
               <LinearGradient
-                colors={[centerGreen, centerGreen]}
+                colors={centerButtonColors}
                 start={{ x: 0.5, y: 0 }}
                 end={{ x: 0.5, y: 1 }}
                 style={styles.centerButton}
               >
                 <View style={styles.centerInnerRing} />
                 <Text style={styles.centerIcon}>
-                  {isActiveJourneyScreen ? "⌂" : isJourneyScreen ? "✓" : "➤"}
+                  {showsHomeCenterButton ? "⌂" : "➤"}
                 </Text>
               </LinearGradient>
             </Pressable>
@@ -235,7 +250,6 @@ const styles = StyleSheet.create({
     height: 68,
     borderRadius: 999,
     overflow: "hidden",
-    shadowColor: centerGreenDeep,
     shadowOpacity: 0.34,
     shadowRadius: 22,
     shadowOffset: { width: 0, height: 10 },

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -10,7 +10,10 @@ import { HomeScreen } from "../screens/HomeScreen";
 import ProfileScreen from "../screens/ProfileScreen"; 
 import SettingsScreen from "../screens/SettingsScreen";
 import StatisticsScreen from "../screens/StatisticsScreen";
-import { RoutesScreen } from "../screens/RoutesScreen";
+import {
+  RoutesScreen,
+  type SavedRouteStartPreset,
+} from "../screens/RoutesScreen";
 import { AlertsScreen } from "../screens/AlertsScreen";
 import { ActiveJourneyScreen } from "../screens/ActiveJourneyScreen";
 import {
@@ -26,6 +29,8 @@ export function AppNavigator() {
   const [currentScreen, setCurrentScreen] = useState<AppScreen>("home");
   const [activeJourneyConfig, setActiveJourneyConfig] =
     useState<StartJourneyConfig | null>(null);
+  const [pendingRoutePreset, setPendingRoutePreset] =
+    useState<SavedRouteStartPreset | null>(null);
 
   // 3. Create a router function to swap the UI based on the state
   const renderScreen = () => {
@@ -36,7 +41,10 @@ export function AppNavigator() {
             onOpenSavedRoutes={() => setCurrentScreen("routes")}
             onOpenPopularRoutes={() => setCurrentScreen("routes")}
             onOpenAlerts={() => setCurrentScreen("alerts")}
-            onOpenStartJourney={() => setCurrentScreen("startJourney")}
+            onOpenStartJourney={() => {
+              setPendingRoutePreset(null);
+              setCurrentScreen("startJourney");
+            }}
             journeyMode={activeJourneyConfig ? "active" : "idle"}
           />
         );
@@ -44,7 +52,10 @@ export function AppNavigator() {
         return (
           <RoutesScreen
             onAlertPress={() => setCurrentScreen("alerts")}
-            onStartRoute={() => setCurrentScreen("startJourney")}
+            onStartRoute={(routePreset) => {
+              setPendingRoutePreset(routePreset);
+              setCurrentScreen("startJourney");
+            }}
           />
         );
       case "profile":
@@ -65,8 +76,10 @@ export function AppNavigator() {
       case "startJourney":
         return (
           <StartJourneyScreen
+            initialRoutePreset={pendingRoutePreset}
             onStartJourney={(journeyConfig) => {
               setActiveJourneyConfig(journeyConfig);
+              setPendingRoutePreset(null);
               setCurrentScreen("activeJourney");
             }}
             onOpenProfile={() => setCurrentScreen("profile")}
@@ -91,7 +104,10 @@ export function AppNavigator() {
             onOpenSavedRoutes={() => setCurrentScreen("routes")}
             onOpenPopularRoutes={() => setCurrentScreen("routes")}
             onOpenAlerts={() => setCurrentScreen("alerts")}
-            onOpenStartJourney={() => setCurrentScreen("startJourney")}
+            onOpenStartJourney={() => {
+              setPendingRoutePreset(null);
+              setCurrentScreen("startJourney");
+            }}
             journeyMode={activeJourneyConfig ? "active" : "idle"}
           />
         ); 
@@ -111,7 +127,12 @@ export function AppNavigator() {
         <NavBar 
           activeScreen={currentScreen} 
           hasActiveJourney={Boolean(activeJourneyConfig)}
-          onNavigate={(screen) => setCurrentScreen(screen)} 
+          onNavigate={(screen) => {
+            if (screen === "startJourney") {
+              setPendingRoutePreset(null);
+            }
+            setCurrentScreen(screen);
+          }} 
         />
         
       </View>

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -12,6 +12,8 @@ import SettingsScreen from "../screens/SettingsScreen";
 import StatisticsScreen from "../screens/StatisticsScreen";
 import {
   RoutesScreen,
+  defaultFavoriteRoute,
+  type FavoriteRouteSummary,
   type SavedRouteStartPreset,
 } from "../screens/RoutesScreen";
 import { AlertsScreen } from "../screens/AlertsScreen";
@@ -31,6 +33,8 @@ export function AppNavigator() {
     useState<StartJourneyConfig | null>(null);
   const [pendingRoutePreset, setPendingRoutePreset] =
     useState<SavedRouteStartPreset | null>(null);
+  const [favoriteRoute, setFavoriteRoute] =
+    useState<FavoriteRouteSummary | null>(defaultFavoriteRoute);
 
   // 3. Create a router function to swap the UI based on the state
   const renderScreen = () => {
@@ -45,6 +49,7 @@ export function AppNavigator() {
               setPendingRoutePreset(null);
               setCurrentScreen("startJourney");
             }}
+            favoriteRoute={favoriteRoute}
             journeyMode={activeJourneyConfig ? "active" : "idle"}
           />
         );
@@ -52,6 +57,8 @@ export function AppNavigator() {
         return (
           <RoutesScreen
             onAlertPress={() => setCurrentScreen("alerts")}
+            favoriteRouteId={favoriteRoute?.routeId ?? null}
+            onFavoriteRouteChange={setFavoriteRoute}
             onStartRoute={(routePreset) => {
               setPendingRoutePreset(routePreset);
               setCurrentScreen("startJourney");
@@ -108,6 +115,7 @@ export function AppNavigator() {
               setPendingRoutePreset(null);
               setCurrentScreen("startJourney");
             }}
+            favoriteRoute={favoriteRoute}
             journeyMode={activeJourneyConfig ? "active" : "idle"}
           />
         ); 

--- a/apps/mobile/src/screens/AlertsScreen.tsx
+++ b/apps/mobile/src/screens/AlertsScreen.tsx
@@ -1,0 +1,20 @@
+import { UnavailableScreen } from "./UnavailableScreen";
+
+type AlertsScreenProps = {
+  onAlertPress: () => void;
+  onViewJourney: () => void;
+};
+
+export function AlertsScreen({
+  onAlertPress: _onAlertPress,
+  onViewJourney,
+}: AlertsScreenProps) {
+  return (
+    <UnavailableScreen
+      title="Alerts are coming back soon"
+      message="Your alerts hub is still being rebuilt, but the rest of the app navigation is live again."
+      actionLabel="View Journey"
+      onActionPress={onViewJourney}
+    />
+  );
+}

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -4,6 +4,7 @@ import { LinearGradient } from "expo-linear-gradient";
 import MapView, { Marker, Polyline } from "react-native-maps";
 import AnimatedWayPointLogo from "../components/AnimatedWayPointLogo";
 import { theme } from "../styles/theme";
+import type { FavoriteRouteSummary } from "./RoutesScreen";
 
 const readyLimeTextDark = "#4F5A22";
 
@@ -41,6 +42,7 @@ type HomeScreenProps = {
   onOpenPopularRoutes: () => void;
   onOpenAlerts: () => void;
   onOpenStartJourney: () => void;
+  favoriteRoute: FavoriteRouteSummary | null;
   journeyMode?: JourneyMode;
 };
 
@@ -89,6 +91,7 @@ export function HomeScreen({
   onOpenPopularRoutes,
   onOpenAlerts,
   onOpenStartJourney,
+  favoriteRoute,
   journeyMode = "idle",
 }: HomeScreenProps) {
   const heroState = heroStateByMode[journeyMode];
@@ -201,11 +204,11 @@ export function HomeScreen({
             <View style={styles.favoriteRoutesRow}>
               {[
                 {
-                  title: "Riverwalk",
-                  subtitle: "Bike loop • 5k",
-                  icon: "↗",
-                  onPress: onOpenPopularRoutes,
-                  tone: "warm" as const,
+                  title: favoriteRoute?.title ?? "Add",
+                  subtitle: favoriteRoute?.subtitle ?? "Favorite",
+                  icon: favoriteRoute ? "★" : "+",
+                  onPress: onOpenSavedRoutes,
+                  tone: favoriteRoute ? ("warm" as const) : ("add" as const),
                 },
                 {
                   title: "School → Home",

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -151,6 +151,8 @@ const sectionAccent: Record<RouteSectionKey, [string, string]> = {
   nearby: ["#D8E5F2", "#B5CBE6"],
 };
 
+const quickFilters = ["Well Lit", "Low Traffic", "Nearby", "Popular"] as const;
+
 export function RoutesScreen({
   onStartRoute,
 }: RoutesScreenProps) {
@@ -158,19 +160,24 @@ export function RoutesScreen({
   const [savedRouteIds, setSavedRouteIds] = useState<string[]>(
     routeSections[0].routes.map((route) => route.id),
   );
+  const [activeQuickFilter, setActiveQuickFilter] = useState<string | null>(null);
 
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
+    const quickFilter = activeQuickFilter?.toLowerCase() ?? "";
 
-    if (!query) {
+    const hasSearch = query.length > 0;
+    const hasQuickFilter = quickFilter.length > 0;
+
+    if (!hasSearch && !hasQuickFilter) {
       return routeSections;
     }
 
     return routeSections
       .map((section) => ({
         ...section,
-        routes: section.routes.filter((route) =>
-          [
+        routes: section.routes.filter((route) => {
+          const searchableText = [
             route.name,
             route.snippet,
             route.distance,
@@ -178,12 +185,18 @@ export function RoutesScreen({
             ...route.tags,
           ]
             .join(" ")
-            .toLowerCase()
-            .includes(query),
-        ),
+            .toLowerCase();
+
+          const matchesSearch = hasSearch ? searchableText.includes(query) : true;
+          const matchesQuickFilter = hasQuickFilter
+            ? route.tags.join(" ").toLowerCase().includes(quickFilter)
+            : true;
+
+          return matchesSearch && matchesQuickFilter;
+        }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue]);
+  }, [searchValue, activeQuickFilter]);
 
   function toggleSavedRoute(routeId: string) {
     setSavedRouteIds((current) =>
@@ -191,6 +204,10 @@ export function RoutesScreen({
         ? current.filter((id) => id !== routeId)
         : [...current, routeId],
     );
+  }
+
+  function toggleQuickFilter(filter: string) {
+    setActiveQuickFilter((current) => (current === filter ? null : filter));
   }
 
   return (
@@ -205,6 +222,16 @@ export function RoutesScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
+        {/* PAGE HEADER */}
+        <View style={styles.pageIntro}>
+          <Text style={styles.pageEyebrow}>Explore</Text>
+          <Text style={styles.pageTitle}>Routes</Text>
+          <Text style={styles.pageSubtitle}>
+            Find a route that feels comfortable, safe, and right for your day.
+          </Text>
+        </View>
+
+        {/* SEARCH */}
         <Pressable
           style={({ pressed }) => [
             styles.searchShell,
@@ -220,6 +247,34 @@ export function RoutesScreen({
             style={styles.searchInput}
           />
         </Pressable>
+
+        {/* QUICK FILTERS */}
+        <View style={styles.filterRow}>
+          {quickFilters.map((filter) => {
+            const selected = activeQuickFilter === filter;
+
+            return (
+              <Pressable
+                key={filter}
+                onPress={() => toggleQuickFilter(filter)}
+                style={({ pressed }) => [
+                  styles.filterPill,
+                  selected && styles.filterPillActive,
+                  pressed && styles.filterPillPressed,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.filterPillText,
+                    selected && styles.filterPillTextActive,
+                  ]}
+                >
+                  {filter}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
 
         {filteredSections.map((section) => (
           <View key={section.key} style={styles.section}>
@@ -360,10 +415,34 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: 16,
-    paddingTop: 24,
+    paddingTop: 22,
     paddingBottom: 180,
     gap: 22,
   },
+
+  pageIntro: {
+    gap: 6,
+  },
+  pageEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
+  },
+  pageTitle: {
+    fontSize: 34,
+    lineHeight: 38,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  pageSubtitle: {
+    fontSize: 15,
+    lineHeight: 22,
+    color: theme.colors.textSoft,
+    maxWidth: 320,
+  },
+
   searchShell: {
     flexDirection: "row",
     alignItems: "center",
@@ -391,6 +470,37 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
     paddingVertical: 0,
   },
+
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    marginTop: -6,
+  },
+  filterPill: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(255,255,255,0.75)",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: "rgba(0,0,0,0.05)",
+  },
+  filterPillActive: {
+    backgroundColor: "rgba(241,176,120,0.18)",
+    borderColor: "rgba(241,176,120,0.35)",
+  },
+  filterPillPressed: {
+    transform: [{ scale: 0.98 }],
+  },
+  filterPillText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  filterPillTextActive: {
+    color: theme.colors.brandDeep,
+  },
+
   section: {
     gap: 14,
     paddingTop: 2,
@@ -432,6 +542,7 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: theme.colors.white,
   },
+
   routeList: {
     gap: 14,
   },
@@ -468,6 +579,7 @@ const styles = StyleSheet.create({
     letterSpacing: 0.4,
     color: theme.colors.brandDeep,
   },
+
   routeCardTopRow: {
     flexDirection: "row",
     alignItems: "flex-start",
@@ -490,6 +602,7 @@ const styles = StyleSheet.create({
     color: theme.colors.textSoft,
     opacity: 0.8,
   },
+
   saveButton: {
     width: 40,
     height: 40,
@@ -511,6 +624,7 @@ const styles = StyleSheet.create({
   saveButtonIconActive: {
     color: theme.colors.brand,
   },
+
   reviewRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -526,6 +640,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     color: theme.colors.textSoft,
   },
+
   tagRow: {
     flexDirection: "row",
     flexWrap: "wrap",
@@ -544,6 +659,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#4F5A22",
   },
+
   cardActions: {
     flexDirection: "row",
     gap: 10,
@@ -588,6 +704,7 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: theme.colors.white,
   },
+
   emptyState: {
     borderRadius: 28,
     backgroundColor: "#FFFFFF",

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -557,73 +557,61 @@ export function RoutesScreen({
         {selectedRoute ? (
           <View style={styles.modalOverlay}>
             <View style={styles.modalCard}>
-              <View style={styles.modalHeader}>
-                <View style={styles.modalHeaderCopy}>
-                  <Text style={styles.modalEyebrow}>Saved Route Details</Text>
-                  {isEditingName ? (
-                    <TextInput
-                      value={editingNameValue}
-                      onChangeText={setEditingNameValue}
-                      placeholder="Route name"
-                      placeholderTextColor={theme.colors.textMuted}
-                      style={styles.modalTitleInput}
-                      autoFocus
-                    />
-                  ) : (
-                    <Text style={styles.modalTitle}>
-                      {routeNames[selectedRoute.id] ?? selectedRoute.name}
+              <LinearGradient
+                colors={["#CFE17A", "#AFCB46"]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.modalReadyCard}
+              >
+                <View style={styles.modalHeader}>
+                  <View style={styles.modalHeaderCopy}>
+                    <Text style={styles.modalReadyEyebrow}>Ready to start?</Text>
+                    {isEditingName ? (
+                      <TextInput
+                        value={editingNameValue}
+                        onChangeText={setEditingNameValue}
+                        placeholder="Route name"
+                        placeholderTextColor="rgba(79,90,34,0.52)"
+                        style={styles.modalReadyTitleInput}
+                        autoFocus
+                      />
+                    ) : (
+                      <Text style={styles.modalReadyTitle}>
+                        {routeNames[selectedRoute.id] ?? selectedRoute.name}
+                      </Text>
+                    )}
+                    <Text style={styles.modalReadyMeta}>
+                      {selectedRoute.distance} • {selectedRoute.time} •{" "}
+                      {editingRouteShapeValue === "loop" ? "Loop" : "One-way"}
                     </Text>
-                  )}
+                  </View>
+                  <Pressable
+                    onPress={cancelEditingRoute}
+                    style={styles.modalCloseButton}
+                  >
+                    <Text style={styles.modalCloseText}>×</Text>
+                  </Pressable>
                 </View>
-                <Pressable
-                  onPress={cancelEditingRoute}
-                  style={styles.modalCloseButton}
-                >
-                  <Text style={styles.modalCloseText}>×</Text>
-                </Pressable>
-              </View>
 
-              <View style={styles.modalMetaRow}>
-                <View style={styles.modalMetaChip}>
-                  <Text style={styles.modalMetaLabel}>Distance</Text>
-                  <Text style={styles.modalMetaValue}>{selectedRoute.distance}</Text>
+                <View style={styles.modalReadySummaryRow}>
+                  {[
+                    editingGroupJourneyValue ? "Group journey" : "Solo journey",
+                    editingGroupJourneyValue ? "2 trusted contacts" : "2 trusted contacts",
+                    `${editingSafetySettingsValue.length}/4 safety settings`,
+                  ].map((item, index, list) => (
+                    <View key={item} style={styles.modalReadySummaryItem}>
+                      <Text style={styles.modalReadySummaryText}>{item}</Text>
+                      {index < list.length - 1 ? (
+                        <Text style={styles.modalReadySummaryDot}>•</Text>
+                      ) : null}
+                    </View>
+                  ))}
                 </View>
-                <View style={styles.modalMetaChip}>
-                  <Text style={styles.modalMetaLabel}>Time</Text>
-                  <Text style={styles.modalMetaValue}>{selectedRoute.time}</Text>
-                </View>
-                <View style={styles.modalMetaChip}>
-                  <Text style={styles.modalMetaLabel}>Route Shape</Text>
-                  <Text style={styles.modalMetaValue}>
-                    {editingRouteShapeValue === "loop" ? "Loop" : "One-way"}
-                  </Text>
-                </View>
-              </View>
-
-              <View style={styles.modalSummaryRow}>
-                <View style={styles.modalSummaryChip}>
-                  <Text style={styles.modalSummaryValue}>
-                    {editingSafetySettingsValue.length}/4
-                  </Text>
-                  <Text style={styles.modalSummaryLabel}>Safety settings</Text>
-                </View>
-                <View style={styles.modalSummaryChip}>
-                  <Text style={styles.modalSummaryValue}>
-                    {editingGroupJourneyValue ? "Group" : "Solo"}
-                  </Text>
-                  <Text style={styles.modalSummaryLabel}>Journey setup</Text>
-                </View>
-                <View style={styles.modalSummaryChip}>
-                  <Text style={styles.modalSummaryValue}>
-                    {savedRouteIds.includes(selectedRoute.id) ? "Saved" : "Not saved"}
-                  </Text>
-                  <Text style={styles.modalSummaryLabel}>Favorite</Text>
-                </View>
-              </View>
+              </LinearGradient>
 
               <View style={styles.modalLocationCard}>
                 <View>
-                  <Text style={styles.modalLocationLabel}>Current Location</Text>
+                  <Text style={styles.modalLocationLabel}>Location</Text>
                   <Text style={styles.modalLocationValue}>
                     {savedRouteRecapDefaults[selectedRoute.id]?.startLocation ??
                       "Current location"}
@@ -1025,30 +1013,48 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 4,
   },
-  modalEyebrow: {
-    fontSize: 12,
-    fontWeight: "800",
-    letterSpacing: 1.4,
-    textTransform: "uppercase",
-    color: theme.colors.textSoft,
+  modalReadyCard: {
+    borderRadius: 30,
+    padding: 24,
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "rgba(86,97,38,0.14)",
+    shadowColor: "#92A93A",
+    shadowOpacity: 0.16,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 8,
   },
-  modalTitle: {
+  modalReadyEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.8,
+    textTransform: "uppercase",
+    color: "rgba(86,97,38,0.82)",
+  },
+  modalReadyTitle: {
     fontSize: 28,
     lineHeight: 32,
     fontWeight: "900",
-    color: theme.colors.text,
+    color: "#4F5A22",
   },
-  modalTitleInput: {
+  modalReadyMeta: {
+    fontSize: 13,
+    lineHeight: 18,
+    fontWeight: "700",
+    color: "rgba(79,90,34,0.74)",
+  },
+  modalReadyTitleInput: {
     borderRadius: 18,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "rgba(255,255,255,0.4)",
     paddingHorizontal: 14,
     paddingVertical: 12,
     borderWidth: 1,
-    borderColor: "#D8C0B0",
+    borderColor: "rgba(79,90,34,0.18)",
     fontSize: 24,
     lineHeight: 28,
     fontWeight: "900",
-    color: theme.colors.text,
+    color: "#4F5A22",
   },
   modalCloseButton: {
     width: 34,
@@ -1056,66 +1062,35 @@ const styles = StyleSheet.create({
     borderRadius: 17,
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: theme.colors.surfaceSoft,
+    backgroundColor: "rgba(79,90,34,0.1)",
+    borderWidth: 1,
+    borderColor: "rgba(79,90,34,0.12)",
   },
   modalCloseText: {
     fontSize: 20,
     lineHeight: 22,
-    color: theme.colors.textSoft,
+    color: "#566126",
   },
-  modalMetaRow: {
+  modalReadySummaryRow: {
     flexDirection: "row",
-    gap: 10,
-  },
-  modalMetaChip: {
-    flex: 1,
-    borderRadius: 18,
-    backgroundColor: "#FFFFFF",
-    paddingHorizontal: 12,
-    paddingVertical: 14,
-    borderWidth: 1,
-    borderColor: "#DFCABC",
-  },
-  modalMetaLabel: {
-    fontSize: 12,
-    fontWeight: "800",
-    letterSpacing: 0.7,
-    textTransform: "uppercase",
-    color: theme.colors.textSoft,
-  },
-  modalMetaValue: {
-    marginTop: 6,
-    fontSize: 15,
-    fontWeight: "900",
-    color: theme.colors.text,
-  },
-  modalSummaryRow: {
-    flexDirection: "row",
-    gap: 10,
-  },
-  modalSummaryChip: {
-    flex: 1,
-    borderRadius: 18,
-    backgroundColor: "#FFFFFF",
-    paddingHorizontal: 12,
-    paddingVertical: 14,
-    borderWidth: 1,
-    borderColor: "#DFCABC",
+    flexWrap: "wrap",
     alignItems: "center",
+    gap: 10,
+    marginTop: 2,
   },
-  modalSummaryValue: {
-    fontSize: 17,
-    fontWeight: "900",
-    color: theme.colors.text,
+  modalReadySummaryItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
-  modalSummaryLabel: {
-    marginTop: 4,
-    fontSize: 12,
-    fontWeight: "800",
-    letterSpacing: 0.4,
-    textTransform: "uppercase",
-    textAlign: "center",
-    color: theme.colors.textSoft,
+  modalReadySummaryDot: {
+    fontSize: 16,
+    color: "#566126",
+  },
+  modalReadySummaryText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "rgba(79,90,34,0.88)",
   },
   modalSection: {
     gap: 10,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -1,0 +1,391 @@
+import { useMemo, useState } from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { theme } from "../styles/theme";
+
+type RouteSectionKey = "saved" | "popular" | "reviewed" | "nearby";
+
+type RouteItem = {
+  id: string;
+  name: string;
+  distance: string;
+  time: string;
+  rating: string;
+  reviews: string;
+  snippet: string;
+  tags: string[];
+};
+
+type RoutesScreenProps = {
+  onStartRoute: () => void;
+  onAlertPress: () => void;
+};
+
+const routeSections: Array<{
+  key: RouteSectionKey;
+  title: string;
+  subtitle: string;
+  routes: RouteItem[];
+}> = [
+  // all the saved / popular / reviewed / nearby route data
+];
+
+const sectionAccent: Record<RouteSectionKey, [string, string]> = {
+  saved: ["#F7D9C9", "#F1B08F"],
+  popular: ["#F4B37E", "#E48C57"],
+  reviewed: ["#D8E59C", "#B9CD62"],
+  nearby: ["#D8E5F2", "#B5CBE6"],
+};
+
+export function RoutesScreen({
+  onStartRoute,
+}: RoutesScreenProps) {
+  const [searchValue, setSearchValue] = useState("");
+  const [savedRouteIds, setSavedRouteIds] = useState<string[]>(
+    routeSections[0].routes.map((route) => route.id),
+  );
+
+  const filteredSections = useMemo(() => {
+    const query = searchValue.trim().toLowerCase();
+
+    if (!query) return routeSections;
+
+    return routeSections
+      .map((section) => ({
+        ...section,
+        routes: section.routes.filter((route) =>
+          [
+            route.name,
+            route.snippet,
+            route.distance,
+            route.time,
+            ...route.tags,
+          ]
+            .join(" ")
+            .toLowerCase()
+            .includes(query),
+        ),
+      }))
+      .filter((section) => section.routes.length > 0);
+  }, [searchValue]);
+
+  function toggleSavedRoute(routeId: string) {
+    setSavedRouteIds((current) =>
+      current.includes(routeId)
+        ? current.filter((id) => id !== routeId)
+        : [...current, routeId],
+    );
+  }
+
+  return (
+    <LinearGradient
+      colors={[theme.colors.background, "#F2E8DD", theme.colors.backgroundDeep]}
+      style={styles.screen}
+    >
+      <ScrollView contentContainerStyle={styles.content}>
+        
+        {/* SEARCH */}
+        <View style={styles.searchShell}>
+          <Text style={styles.searchIcon}>⌕</Text>
+          <TextInput
+            value={searchValue}
+            onChangeText={setSearchValue}
+            placeholder="Search routes, areas, or safety tags"
+            placeholderTextColor={theme.colors.textMuted}
+            style={styles.searchInput}
+          />
+        </View>
+
+        {/* SECTIONS */}
+        {filteredSections.map((section) => (
+          <View key={section.key} style={styles.section}>
+            
+            {/* HEADER */}
+            <View style={styles.sectionHeader}>
+              <View>
+                <Text style={styles.sectionTitle}>{section.title}</Text>
+                <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
+              </View>
+
+              <LinearGradient
+                colors={sectionAccent[section.key]}
+                style={styles.sectionBadge}
+              >
+                <Text style={styles.sectionBadgeText}>
+                  {section.key === "reviewed"
+                    ? "Top rated"
+                    : section.key === "nearby"
+                    ? "Near you"
+                    : section.key === "saved"
+                    ? "Personal"
+                    : "Trending"}
+                </Text>
+              </LinearGradient>
+            </View>
+
+            {/* ROUTES */}
+            <View style={styles.routeList}>
+              {section.routes.map((route) => {
+                const isSaved = savedRouteIds.includes(route.id);
+
+                return (
+                  <View key={route.id} style={styles.routeCard}>
+                    
+                    <View style={styles.routeCardTopRow}>
+                      <View style={styles.routeCopy}>
+                        <Text style={styles.routeName}>{route.name}</Text>
+                        <Text style={styles.routeMeta}>
+                          {route.distance} • {route.time}
+                        </Text>
+                      </View>
+
+                      <Pressable
+                        onPress={() => toggleSavedRoute(route.id)}
+                        style={[
+                          styles.saveButton,
+                          isSaved && styles.saveButtonActive,
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.saveButtonIcon,
+                            isSaved && styles.saveButtonIconActive,
+                          ]}
+                        >
+                          ♥
+                        </Text>
+                      </Pressable>
+                    </View>
+
+                    <Text style={styles.reviewRating}>
+                      ★ {route.rating} ({route.reviews})
+                    </Text>
+
+                    <Text style={styles.reviewSnippet}>
+                      “{route.snippet}”
+                    </Text>
+
+                    <View style={styles.tagRow}>
+                      {route.tags.map((tag) => (
+                        <View key={tag} style={styles.tag}>
+                          <Text style={styles.tagText}>{tag}</Text>
+                        </View>
+                      ))}
+                    </View>
+
+                    <View style={styles.cardActions}>
+                      <Pressable style={styles.secondaryAction}>
+                        <Text style={styles.secondaryActionText}>
+                          {isSaved ? "Saved" : "Save"}
+                        </Text>
+                      </Pressable>
+
+                      <Pressable
+                        onPress={onStartRoute}
+                        style={styles.primaryAction}
+                      >
+                        <Text style={styles.primaryActionText}>
+                          Start Route
+                        </Text>
+                      </Pressable>
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+
+  content: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    paddingBottom: 180,
+    gap: 18,
+  },
+
+  // SEARCH UPGRADE
+  searchShell: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    borderRadius: 24,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.12,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 6,
+  },
+
+  searchIcon: {
+    fontSize: 18,
+    color: theme.colors.textMuted,
+  },
+
+  searchInput: {
+    flex: 1,
+    fontSize: 16,
+    color: theme.colors.text,
+  },
+
+  section: { gap: 12 },
+
+  sectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+
+  sectionTitle: {
+    fontSize: 22,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+
+  sectionSubtitle: {
+    fontSize: 13,
+    color: theme.colors.textSoft,
+    opacity: 0.8,
+  },
+
+  sectionBadge: {
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+
+  sectionBadgeText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#fff",
+  },
+
+  routeList: { gap: 12 },
+
+  // CARD UPGRADE
+  routeCard: {
+    borderRadius: 28,
+    backgroundColor: "#FFFFFF",
+    padding: 18,
+    gap: 12,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.12,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 6,
+  },
+
+  routeCardTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+
+  routeCopy: { flex: 1 },
+
+  routeName: {
+    fontSize: 20,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+
+  routeMeta: {
+    fontSize: 13,
+    color: theme.colors.textSoft,
+    opacity: 0.8,
+  },
+
+  saveButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 14,
+    backgroundColor: "rgba(0,0,0,0.05)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  saveButtonActive: {
+    backgroundColor: "rgba(241,176,120,0.25)",
+  },
+
+  saveButtonIcon: {
+    color: theme.colors.textMuted,
+  },
+
+  saveButtonIconActive: {
+    color: theme.colors.brand,
+  },
+
+  reviewRating: {
+    fontWeight: "700",
+    color: theme.colors.brandDeep,
+  },
+
+  reviewSnippet: {
+    color: theme.colors.textSoft,
+  },
+
+  // TAG FIX
+  tag: {
+    backgroundColor: "rgba(175,203,70,0.15)",
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+
+  tagText: {
+    fontSize: 12,
+    color: "#4F5A22",
+  },
+
+  tagRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+
+  cardActions: {
+    flexDirection: "row",
+    gap: 10,
+  },
+
+  secondaryAction: {
+    flex: 1,
+    borderRadius: 20,
+    backgroundColor: "rgba(0,0,0,0.04)",
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+
+  primaryAction: {
+    flex: 1.3,
+    borderRadius: 20,
+    backgroundColor: theme.colors.brand,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+
+  primaryActionText: {
+    color: "#fff",
+    fontWeight: "800",
+  },
+
+  secondaryActionText: {
+    color: theme.colors.text,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -54,22 +54,22 @@ const routeSections: Array<{
     routes: [
       {
         id: "saved-morning-walk",
-        name: "Morning Walk",
+        name: "River Parks Morning Walk",
         distance: "2.1 mi",
         time: "42 min",
         rating: "4.8",
         reviews: "18 reviews",
-        snippet: "Easy to follow and feels calm before work.",
+        snippet: "Easy to follow along Riverside and feels calm before work.",
         tags: ["Well Lit", "Low Traffic", "Easy Pace"],
       },
       {
         id: "saved-park-loop",
-        name: "Park Loop",
+        name: "Gathering Place Loop",
         distance: "3.0 mi",
         time: "58 min",
         rating: "4.7",
         reviews: "26 reviews",
-        snippet: "Open paths and lots of visibility the whole way.",
+        snippet: "Open paths, clear signage, and lots of visibility through the park.",
         tags: ["Open Views", "Popular", "Moderate Crowd"],
       },
     ],
@@ -81,22 +81,22 @@ const routeSections: Array<{
     routes: [
       {
         id: "popular-riverwalk",
-        name: "Riverwalk Loop",
+        name: "Gathering Place Riverwalk",
         distance: "2.8 mi",
         time: "51 min",
         rating: "4.6",
         reviews: "32 reviews",
-        snippet: "Well lit and great for evening walks.",
+        snippet: "Well lit and great for evening walks near the river.",
         tags: ["Well Lit", "Moderate Crowd", "Smooth Path"],
       },
       {
         id: "popular-downtown",
-        name: "Downtown Out-and-Back",
+        name: "Blue Dome Out-and-Back",
         distance: "1.9 mi",
         time: "36 min",
         rating: "4.5",
         reviews: "24 reviews",
-        snippet: "Busy enough to feel comfortable but still easy to pace.",
+        snippet: "Busy enough to feel comfortable but still easy to pace through downtown Tulsa.",
         tags: ["Busy Area", "Shops Nearby", "Quick Route"],
       },
     ],
@@ -108,22 +108,22 @@ const routeSections: Array<{
     routes: [
       {
         id: "reviewed-greenway",
-        name: "Greenway Path",
+        name: "Turkey Mountain Lower Trail",
         distance: "4.2 mi",
         time: "1 hr 12 min",
         rating: "4.9",
         reviews: "41 reviews",
-        snippet: "Feels safe even after sunset because the lighting is consistent.",
+        snippet: "A trusted Tulsa favorite with a route people know well and return to often.",
         tags: ["Well Lit", "Trusted", "Low Traffic"],
       },
       {
         id: "reviewed-campus",
-        name: "Campus Connector",
+        name: "Utica Square Connector",
         distance: "2.4 mi",
         time: "44 min",
         rating: "4.7",
         reviews: "29 reviews",
-        snippet: "A good mix of visibility, people around, and easy landmarks.",
+        snippet: "A good mix of visibility, people around, and easy-to-follow Tulsa landmarks.",
         tags: ["Landmarks", "Moderate Crowd", "Easy Navigation"],
       },
     ],
@@ -135,22 +135,22 @@ const routeSections: Array<{
     routes: [
       {
         id: "nearby-lake",
-        name: "Lakeside Route",
+        name: "Swan Lake Circuit",
         distance: "1.6 mi",
         time: "31 min",
         rating: "4.4",
         reviews: "15 reviews",
-        snippet: "Short, scenic, and simple when you want something close.",
+        snippet: "Short, scenic, and simple when you want something close in midtown Tulsa.",
         tags: ["Nearby", "Scenic", "Light Traffic"],
       },
       {
         id: "nearby-market",
-        name: "Market Street Loop",
+        name: "Cherry Street Loop",
         distance: "2.0 mi",
         time: "38 min",
         rating: "4.3",
         reviews: "12 reviews",
-        snippet: "Useful for quick daytime walks with plenty of activity nearby.",
+        snippet: "Useful for quick daytime walks with plenty of activity and cafes nearby.",
         tags: ["Daytime", "Busy Area", "Quick Route"],
       },
     ],
@@ -193,17 +193,20 @@ const savedRouteRecapDefaults: Record<
     routeShape: RouteShape;
     safetyFeatureIds: string[];
     journeyMode: "Solo" | "Group";
+    startLocation: string;
   }
 > = {
   "saved-morning-walk": {
     routeShape: "loop",
     safetyFeatureIds: ["off-route", "check-ins"],
     journeyMode: "Solo",
+    startLocation: "River Parks Trail, Tulsa",
   },
   "saved-park-loop": {
     routeShape: "loop",
     safetyFeatureIds: ["off-route", "missed-check-in", "emergency"],
     journeyMode: "Group",
+    startLocation: "Gathering Place, Tulsa",
   },
 };
 
@@ -618,20 +621,14 @@ export function RoutesScreen({
                 </View>
               </View>
 
-              <View style={styles.modalSection}>
-                <Text style={styles.modalSectionTitle}>Review Summary</Text>
-                <Text style={styles.modalReviewRating}>
-                  ★ {selectedRoute.rating} ({selectedRoute.reviews})
-                </Text>
-                <TextInput
-                  value={editingReviewValue}
-                  onChangeText={setEditingReviewValue}
-                  placeholder="Update your review"
-                  placeholderTextColor={theme.colors.textMuted}
-                  style={styles.reviewInput}
-                  multiline
-                  textAlignVertical="top"
-                />
+              <View style={styles.modalLocationCard}>
+                <View>
+                  <Text style={styles.modalLocationLabel}>Current Location</Text>
+                  <Text style={styles.modalLocationValue}>
+                    {savedRouteRecapDefaults[selectedRoute.id]?.startLocation ??
+                      "Current location"}
+                  </Text>
+                </View>
               </View>
 
               <View style={styles.modalSection}>
@@ -1131,6 +1128,30 @@ const styles = StyleSheet.create({
   modalSectionTitle: {
     fontSize: 15,
     fontWeight: "800",
+    color: theme.colors.text,
+  },
+  modalLocationCard: {
+    borderRadius: 22,
+    backgroundColor: theme.colors.surfaceOrangeDeep,
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+    borderWidth: 1,
+    borderColor: "rgba(202,116,73,0.3)",
+  },
+  modalLocationLabel: {
+    fontSize: 13,
+    color: "rgba(111,72,46,0.86)",
+    fontWeight: "700",
+  },
+  modalLocationValue: {
+    marginTop: 3,
+    fontSize: 20,
+    lineHeight: 24,
+    fontWeight: "900",
     color: theme.colors.text,
   },
   modalReviewRating: {

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Feather } from "@expo/vector-icons";
 import {
   Modal,
@@ -43,6 +43,7 @@ type RoutesScreenProps = {
 type RouteShape = "oneWay" | "loop";
 
 const warningOrange = "#E58B5B";
+const navSlate = "#778093";
 
 const routeSections: Array<{
   key: RouteSectionKey;
@@ -236,6 +237,32 @@ export function RoutesScreen({
   const [editingGroupJourneyValue, setEditingGroupJourneyValue] = useState(false);
   const [isReviewComposerOpen, setIsReviewComposerOpen] = useState(false);
   const [pendingRemovalRouteId, setPendingRemovalRouteId] = useState<string | null>(null);
+  const [saveToastMessage, setSaveToastMessage] = useState<string | null>(null);
+
+  const allRoutes = useMemo(
+    () => routeSections.flatMap((section) => section.routes),
+    [],
+  );
+  const routeLookup = useMemo(
+    () =>
+      allRoutes.reduce<Record<string, RouteItem>>((current, route) => {
+        current[route.id] = route;
+        return current;
+      }, {}),
+    [allRoutes],
+  );
+
+  useEffect(() => {
+    if (!saveToastMessage) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      setSaveToastMessage(null);
+    }, 2200);
+
+    return () => clearTimeout(timeoutId);
+  }, [saveToastMessage]);
 
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
@@ -245,10 +272,12 @@ export function RoutesScreen({
     return routeSections
       .map((section) => ({
         ...section,
-        routes: section.routes.filter((route) => {
-          if (section.key === "saved" && !savedRouteIds.includes(route.id)) {
-            return false;
-          }
+        routes: (section.key === "saved"
+          ? savedRouteIds
+              .map((routeId) => routeLookup[routeId])
+              .filter((route): route is RouteItem => Boolean(route))
+          : section.routes
+        ).filter((route) => {
 
           const routeName = route.name;
           const routeReview = routeReviews[route.id] ?? route.snippet;
@@ -272,29 +301,29 @@ export function RoutesScreen({
         }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue, activeQuickFilter, routeReviews, routeReviewTags, savedRouteIds]);
+  }, [searchValue, activeQuickFilter, routeLookup, routeReviews, routeReviewTags, savedRouteIds]);
 
   const savedSection = filteredSections.find((section) => section.key === "saved");
   const otherSections = filteredSections.filter((section) => section.key !== "saved");
   const selectedRoute =
     editingRouteId === null
       ? null
-      : routeSections
-          .flatMap((section) => section.routes)
-          .find((route) => route.id === editingRouteId) ?? null;
+      : routeLookup[editingRouteId] ?? null;
   const pendingRemovalRoute =
     pendingRemovalRouteId === null
       ? null
-      : routeSections
-          .flatMap((section) => section.routes)
-          .find((route) => route.id === pendingRemovalRouteId) ?? null;
+      : routeLookup[pendingRemovalRouteId] ?? null;
 
-  function toggleSavedRoute(routeId: string) {
-    setSavedRouteIds((current) =>
-      current.includes(routeId)
-        ? current.filter((id) => id !== routeId)
-        : [...current, routeId],
-    );
+  function toggleSavedRoute(route: RouteItem) {
+    const isAlreadySaved = savedRouteIds.includes(route.id);
+
+    if (isAlreadySaved) {
+      requestRemoveFromSaved(route.id);
+      return;
+    }
+
+    setSavedRouteIds((current) => [...current, route.id]);
+    setSaveToastMessage(`${route.name} added to saved routes!`);
   }
 
   function removeFromSaved(routeId: string) {
@@ -457,7 +486,7 @@ export function RoutesScreen({
                     </Text>
                   </View>
                   <Pressable
-                    onPress={() => toggleSavedRoute(route.id)}
+                    onPress={() => toggleSavedRoute(route)}
                     style={[
                       styles.saveButton,
                       isSaved && styles.saveButtonActive,
@@ -494,7 +523,7 @@ export function RoutesScreen({
                     onPress={() =>
                       canEditRoute
                         ? startEditingRoute(route)
-                        : toggleSavedRoute(route.id)
+                        : toggleSavedRoute(route)
                     }
                     style={styles.secondaryAction}
                   >
@@ -509,14 +538,6 @@ export function RoutesScreen({
                     <Text style={styles.primaryActionText}>Start Route</Text>
                   </Pressable>
                 </View>
-                {canEditRoute ? (
-                  <Pressable
-                    onPress={() => requestRemoveFromSaved(route.id)}
-                    style={styles.removeSavedButton}
-                  >
-                    <Text style={styles.removeSavedButtonText}>Unsave</Text>
-                  </Pressable>
-                ) : null}
               </View>
             );
           })}
@@ -537,6 +558,11 @@ export function RoutesScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
+        {saveToastMessage ? (
+          <View style={styles.saveToast}>
+            <Text style={styles.saveToastText}>{saveToastMessage}</Text>
+          </View>
+        ) : null}
         <View style={styles.pageIntroRow}>
           <View style={styles.pageIntro}>
             <Text style={styles.pageEyebrow}>Explore</Text>
@@ -889,6 +915,26 @@ const styles = StyleSheet.create({
     paddingTop: 28,
     paddingBottom: 180,
     gap: 18,
+  },
+  saveToast: {
+    borderRadius: 20,
+    backgroundColor: "#F7FBEC",
+    borderWidth: 1,
+    borderColor: "rgba(146,169,58,0.28)",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    shadowColor: "#92A93A",
+    shadowOpacity: 0.14,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+  },
+  saveToastText: {
+    fontSize: 14,
+    lineHeight: 20,
+    fontWeight: "800",
+    color: "#4F5A22",
+    textAlign: "center",
   },
   pageIntro: {
     gap: 6,
@@ -1416,12 +1462,12 @@ const styles = StyleSheet.create({
   removeConfirmCard: {
     width: "100%",
     borderRadius: 28,
-    backgroundColor: warningOrange,
+    backgroundColor: theme.colors.brand,
     padding: 22,
     gap: 16,
     borderWidth: 1,
-    borderColor: warningOrange,
-    shadowColor: warningOrange,
+    borderColor: theme.colors.brand,
+    shadowColor: theme.colors.brand,
     shadowOpacity: 0.18,
     shadowRadius: 18,
     shadowOffset: { width: 0, height: 10 },

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -21,8 +21,6 @@ type RouteItem = {
   reviews: string;
   snippet: string;
   tags: string[];
-  safetyScore: string;
-  crowdLevel: string;
 };
 
 type RoutesScreenProps = {
@@ -50,8 +48,6 @@ const routeSections: Array<{
         reviews: "18 reviews",
         snippet: "Easy to follow and feels calm before work.",
         tags: ["Well Lit", "Low Traffic", "Easy Pace"],
-        safetyScore: "High",
-        crowdLevel: "Light",
       },
       {
         id: "saved-park-loop",
@@ -62,8 +58,6 @@ const routeSections: Array<{
         reviews: "26 reviews",
         snippet: "Open paths and lots of visibility the whole way.",
         tags: ["Open Views", "Popular", "Moderate Crowd"],
-        safetyScore: "High",
-        crowdLevel: "Moderate",
       },
     ],
   },
@@ -81,8 +75,6 @@ const routeSections: Array<{
         reviews: "32 reviews",
         snippet: "Well lit and great for evening walks.",
         tags: ["Well Lit", "Moderate Crowd", "Smooth Path"],
-        safetyScore: "High",
-        crowdLevel: "Moderate",
       },
       {
         id: "popular-downtown",
@@ -93,8 +85,6 @@ const routeSections: Array<{
         reviews: "24 reviews",
         snippet: "Busy enough to feel comfortable but still easy to pace.",
         tags: ["Busy Area", "Shops Nearby", "Quick Route"],
-        safetyScore: "Medium",
-        crowdLevel: "Busy",
       },
     ],
   },
@@ -112,8 +102,6 @@ const routeSections: Array<{
         reviews: "41 reviews",
         snippet: "Feels safe even after sunset because the lighting is consistent.",
         tags: ["Well Lit", "Trusted", "Low Traffic"],
-        safetyScore: "High",
-        crowdLevel: "Light",
       },
       {
         id: "reviewed-campus",
@@ -124,8 +112,6 @@ const routeSections: Array<{
         reviews: "29 reviews",
         snippet: "A good mix of visibility, people around, and easy landmarks.",
         tags: ["Landmarks", "Moderate Crowd", "Easy Navigation"],
-        safetyScore: "High",
-        crowdLevel: "Moderate",
       },
     ],
   },
@@ -143,8 +129,6 @@ const routeSections: Array<{
         reviews: "15 reviews",
         snippet: "Short, scenic, and simple when you want something close.",
         tags: ["Nearby", "Scenic", "Light Traffic"],
-        safetyScore: "Medium",
-        crowdLevel: "Light",
       },
       {
         id: "nearby-market",
@@ -155,8 +139,6 @@ const routeSections: Array<{
         reviews: "12 reviews",
         snippet: "Useful for quick daytime walks with plenty of activity nearby.",
         tags: ["Daytime", "Busy Area", "Quick Route"],
-        safetyScore: "Medium",
-        crowdLevel: "Busy",
       },
     ],
   },
@@ -179,15 +161,16 @@ export function RoutesScreen({
     routeSections[0].routes.map((route) => route.id),
   );
   const [activeQuickFilter, setActiveQuickFilter] = useState<string | null>(null);
+  const [routeNames, setRouteNames] = useState<Record<string, string>>({});
+  const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
+  const [editingNameValue, setEditingNameValue] = useState("");
 
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
     const quickFilter = activeQuickFilter?.toLowerCase() ?? "";
-
-    const hasSearch = query.length > 0;
     const hasQuickFilter = quickFilter.length > 0;
 
-    if (!hasSearch && !hasQuickFilter) {
+    if (!query && !hasQuickFilter) {
       return routeSections;
     }
 
@@ -195,19 +178,18 @@ export function RoutesScreen({
       .map((section) => ({
         ...section,
         routes: section.routes.filter((route) => {
+          const routeName = routeNames[route.id] ?? route.name;
           const searchableText = [
-            route.name,
+            routeName,
             route.snippet,
             route.distance,
             route.time,
-            route.safetyScore,
-            route.crowdLevel,
             ...route.tags,
           ]
             .join(" ")
             .toLowerCase();
 
-          const matchesSearch = hasSearch ? searchableText.includes(query) : true;
+          const matchesSearch = query ? searchableText.includes(query) : true;
           const matchesQuickFilter = hasQuickFilter
             ? route.tags.join(" ").toLowerCase().includes(quickFilter)
             : true;
@@ -216,7 +198,10 @@ export function RoutesScreen({
         }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue, activeQuickFilter]);
+  }, [searchValue, activeQuickFilter, routeNames]);
+
+  const savedSection = filteredSections.find((section) => section.key === "saved");
+  const otherSections = filteredSections.filter((section) => section.key !== "saved");
 
   function toggleSavedRoute(routeId: string) {
     setSavedRouteIds((current) =>
@@ -228,6 +213,163 @@ export function RoutesScreen({
 
   function toggleQuickFilter(filter: string) {
     setActiveQuickFilter((current) => (current === filter ? null : filter));
+  }
+
+  function startEditingRoute(route: RouteItem) {
+    setEditingRouteId(route.id);
+    setEditingNameValue(routeNames[route.id] ?? route.name);
+  }
+
+  function cancelEditingRoute() {
+    setEditingRouteId(null);
+    setEditingNameValue("");
+  }
+
+  function saveRouteName(route: RouteItem) {
+    const trimmedName = editingNameValue.trim();
+
+    if (!trimmedName) {
+      cancelEditingRoute();
+      return;
+    }
+
+    setRouteNames((current) => ({
+      ...current,
+      [route.id]: trimmedName,
+    }));
+    cancelEditingRoute();
+  }
+
+  function renderSection(section: (typeof routeSections)[number]) {
+    return (
+      <View key={section.key} style={styles.section}>
+        <View style={styles.sectionHeader}>
+          <View>
+            <Text style={styles.sectionTitle}>{section.title}</Text>
+            <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
+          </View>
+          <LinearGradient
+            colors={sectionAccent[section.key]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={styles.sectionBadge}
+          >
+            <Text style={styles.sectionBadgeText}>
+              {section.key === "reviewed"
+                ? "Top rated"
+                : section.key === "nearby"
+                  ? "Near you"
+                  : section.key === "saved"
+                    ? "Personal"
+                    : "Trending"}
+            </Text>
+          </LinearGradient>
+        </View>
+
+        <View style={styles.routeList}>
+          {section.routes.map((route) => {
+            const isSaved = savedRouteIds.includes(route.id);
+            const canEditRoute = section.key === "saved";
+            const routeName = routeNames[route.id] ?? route.name;
+            const isEditing = canEditRoute && editingRouteId === route.id;
+
+            return (
+              <View key={route.id} style={styles.routeCard}>
+                <View style={styles.routeCardTopRow}>
+                  <View style={styles.routeCopy}>
+                    {isEditing ? (
+                      <TextInput
+                        value={editingNameValue}
+                        onChangeText={setEditingNameValue}
+                        placeholder="Rename route"
+                        placeholderTextColor={theme.colors.textMuted}
+                        style={styles.routeNameInput}
+                      />
+                    ) : (
+                      <Text style={styles.routeName}>{routeName}</Text>
+                    )}
+                    <Text style={styles.routeMeta}>
+                      {route.distance} • {route.time}
+                    </Text>
+                  </View>
+                  <Pressable
+                    onPress={() => toggleSavedRoute(route.id)}
+                    style={[
+                      styles.saveButton,
+                      isSaved && styles.saveButtonActive,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.saveButtonIcon,
+                        isSaved && styles.saveButtonIconActive,
+                      ]}
+                    >
+                      ♥
+                    </Text>
+                  </Pressable>
+                </View>
+
+                <View style={styles.reviewRow}>
+                  <Text style={styles.reviewRating}>
+                    ★ {route.rating} ({route.reviews})
+                  </Text>
+                </View>
+                <Text style={styles.reviewSnippet}>“{route.snippet}”</Text>
+
+                <View style={styles.tagRow}>
+                  {route.tags.map((tag) => (
+                    <View key={tag} style={styles.tag}>
+                      <Text style={styles.tagText}>{tag}</Text>
+                    </View>
+                  ))}
+                </View>
+
+                <View style={styles.cardActions}>
+                  {isEditing ? (
+                    <>
+                      <Pressable
+                        onPress={cancelEditingRoute}
+                        style={styles.secondaryAction}
+                      >
+                        <Text style={styles.secondaryActionText}>Cancel</Text>
+                      </Pressable>
+                      <Pressable
+                        onPress={() => saveRouteName(route)}
+                        style={styles.primaryAction}
+                      >
+                        <Text style={styles.primaryActionText}>Save Name</Text>
+                      </Pressable>
+                    </>
+                  ) : (
+                    <>
+                      <Pressable
+                        onPress={() =>
+                          canEditRoute
+                            ? startEditingRoute(route)
+                            : toggleSavedRoute(route.id)
+                        }
+                        style={styles.secondaryAction}
+                      >
+                        <Text style={styles.secondaryActionText}>
+                          {canEditRoute ? "Edit" : isSaved ? "Saved" : "Save"}
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        onPress={onStartRoute}
+                        style={styles.primaryAction}
+                      >
+                        <Text style={styles.primaryActionText}>Start Route</Text>
+                      </Pressable>
+                    </>
+                  )}
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      </View>
+    );
   }
 
   return (
@@ -250,12 +392,7 @@ export function RoutesScreen({
           </Text>
         </View>
 
-        <Pressable
-          style={({ pressed }) => [
-            styles.searchShell,
-            pressed && styles.searchShellPressed,
-          ]}
-        >
+        <View style={styles.searchShell}>
           <Text style={styles.searchIcon}>⌕</Text>
           <TextInput
             value={searchValue}
@@ -264,7 +401,7 @@ export function RoutesScreen({
             placeholderTextColor={theme.colors.textMuted}
             style={styles.searchInput}
           />
-        </Pressable>
+        </View>
 
         <View style={styles.filterRow}>
           {quickFilters.map((filter) => {
@@ -274,10 +411,9 @@ export function RoutesScreen({
               <Pressable
                 key={filter}
                 onPress={() => toggleQuickFilter(filter)}
-                style={({ pressed }) => [
+                style={[
                   styles.filterPill,
                   selected && styles.filterPillActive,
-                  pressed && styles.filterPillPressed,
                 ]}
               >
                 <Text
@@ -293,137 +429,18 @@ export function RoutesScreen({
           })}
         </View>
 
-        {filteredSections.map((section) => (
-          <View key={section.key} style={styles.section}>
-            <View style={styles.sectionHeader}>
-              <View style={styles.sectionTitleWrap}>
-                <Text style={styles.sectionTitle}>{section.title}</Text>
-                <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
-              </View>
-
-              <LinearGradient
-                colors={sectionAccent[section.key]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={styles.sectionBadge}
-              >
-                <Text style={styles.sectionBadgeText}>
-                  {section.key === "reviewed"
-                    ? "Top rated"
-                    : section.key === "nearby"
-                      ? "Near you"
-                      : section.key === "saved"
-                        ? "Personal"
-                        : "Trending"}
-                </Text>
-              </LinearGradient>
-            </View>
-
-            <View style={styles.routeList}>
-              {section.routes.map((route, index) => {
-                const isSaved = savedRouteIds.includes(route.id);
-                const isFeatured = index === 0;
-
-                return (
-                  <Pressable
-                    key={route.id}
-                    style={({ pressed }) => [
-                      styles.routeCard,
-                      isFeatured && styles.routeCardFeatured,
-                      pressed && styles.routeCardPressed,
-                    ]}
-                  >
-                    {isFeatured ? (
-                      <View style={styles.featuredPill}>
-                        <Text style={styles.featuredPillText}>Recommended</Text>
-                      </View>
-                    ) : null}
-
-                    <View style={styles.routeCardTopRow}>
-                      <View style={styles.routeCopy}>
-                        <Text style={styles.routeName}>{route.name}</Text>
-                        <Text style={styles.routeMeta}>
-                          {route.distance} • {route.time}
-                        </Text>
-                      </View>
-
-                      <Pressable
-                        onPress={() => toggleSavedRoute(route.id)}
-                        style={({ pressed }) => [
-                          styles.saveButton,
-                          isSaved && styles.saveButtonActive,
-                          pressed && styles.saveButtonPressed,
-                        ]}
-                      >
-                        <Text
-                          style={[
-                            styles.saveButtonIcon,
-                            isSaved && styles.saveButtonIconActive,
-                          ]}
-                        >
-                          ♥
-                        </Text>
-                      </Pressable>
-                    </View>
-
-                    <View style={styles.infoChipRow}>
-                      <View style={[styles.infoChip, styles.safetyChip]}>
-                        <Text style={styles.infoChipLabel}>Safety</Text>
-                        <Text style={styles.infoChipValue}>{route.safetyScore}</Text>
-                      </View>
-                      <View style={[styles.infoChip, styles.crowdChip]}>
-                        <Text style={styles.infoChipLabel}>Crowd</Text>
-                        <Text style={styles.infoChipValue}>{route.crowdLevel}</Text>
-                      </View>
-                    </View>
-
-                    <View style={styles.divider} />
-
-                    <View style={styles.reviewRow}>
-                      <Text style={styles.reviewRating}>
-                        ★ {route.rating} ({route.reviews})
-                      </Text>
-                    </View>
-
-                    <Text style={styles.reviewSnippet}>“{route.snippet}”</Text>
-
-                    <View style={styles.tagRow}>
-                      {route.tags.map((tag) => (
-                        <View key={tag} style={styles.tag}>
-                          <Text style={styles.tagText}>{tag}</Text>
-                        </View>
-                      ))}
-                    </View>
-
-                    <View style={styles.cardActions}>
-                      <Pressable
-                        onPress={() => toggleSavedRoute(route.id)}
-                        style={({ pressed }) => [
-                          styles.secondaryAction,
-                          pressed && styles.secondaryActionPressed,
-                        ]}
-                      >
-                        <Text style={styles.secondaryActionText}>
-                          {isSaved ? "Saved" : "Save"}
-                        </Text>
-                      </Pressable>
-
-                      <Pressable
-                        onPress={onStartRoute}
-                        style={({ pressed }) => [
-                          styles.primaryAction,
-                          pressed && styles.primaryActionPressed,
-                        ]}
-                      >
-                        <Text style={styles.primaryActionText}>Start Route</Text>
-                      </Pressable>
-                    </View>
-                  </Pressable>
-                );
-              })}
-            </View>
+        {savedSection ? (
+          <View style={styles.topSectionWrap}>
+            {renderSection(savedSection)}
           </View>
-        ))}
+        ) : null}
+
+        {otherSections.length > 0 ? (
+          <View style={styles.moreSectionWrap}>
+            <Text style={styles.moreSectionTitle}>More Routes</Text>
+            {otherSections.map(renderSection)}
+          </View>
+        ) : null}
 
         {filteredSections.length === 0 ? (
           <View style={styles.emptyState}>
@@ -444,12 +461,11 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colors.background,
   },
   content: {
-    paddingHorizontal: 16,
-    paddingTop: 22,
+    paddingHorizontal: 18,
+    paddingTop: 28,
     paddingBottom: 180,
-    gap: 22,
+    gap: 18,
   },
-
   pageIntro: {
     gap: 6,
   },
@@ -472,23 +488,19 @@ const styles = StyleSheet.create({
     color: theme.colors.textSoft,
     maxWidth: 320,
   },
-
   searchShell: {
     flexDirection: "row",
     alignItems: "center",
     gap: 10,
     borderRadius: 24,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "rgba(255,250,247,0.96)",
     paddingHorizontal: 16,
     paddingVertical: 14,
     shadowColor: theme.colors.brandDeep,
-    shadowOpacity: 0.12,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 6,
-  },
-  searchShellPressed: {
-    transform: [{ scale: 0.995 }],
+    shadowOpacity: 0.08,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
   },
   searchIcon: {
     fontSize: 18,
@@ -496,31 +508,28 @@ const styles = StyleSheet.create({
   },
   searchInput: {
     flex: 1,
-    fontSize: 16,
+    fontSize: 15,
     color: theme.colors.text,
     paddingVertical: 0,
   },
-
   filterRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 10,
-    marginTop: -6,
   },
   filterPill: {
     borderRadius: theme.radius.pill,
-    backgroundColor: "rgba(255,255,255,0.75)",
+    backgroundColor: "rgba(255,250,247,0.96)",
     paddingHorizontal: 14,
     paddingVertical: 10,
-    borderWidth: 1,
-    borderColor: "rgba(0,0,0,0.05)",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.06,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
   },
   filterPillActive: {
-    backgroundColor: "rgba(241,176,120,0.18)",
-    borderColor: "rgba(241,176,120,0.35)",
-  },
-  filterPillPressed: {
-    transform: [{ scale: 0.98 }],
+    backgroundColor: "rgba(241,176,120,0.22)",
   },
   filterPillText: {
     fontSize: 13,
@@ -530,86 +539,64 @@ const styles = StyleSheet.create({
   filterPillTextActive: {
     color: theme.colors.brandDeep,
   },
-
   section: {
     gap: 14,
-    paddingTop: 2,
+  },
+  topSectionWrap: {
+    gap: 14,
+  },
+  moreSectionWrap: {
+    gap: 18,
+    paddingTop: 8,
+  },
+  moreSectionTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
   },
   sectionHeader: {
     flexDirection: "row",
-    alignItems: "flex-end",
+    alignItems: "center",
     justifyContent: "space-between",
     gap: 12,
   },
-  sectionTitleWrap: {
-    flex: 1,
-    gap: 4,
-  },
   sectionTitle: {
-    fontSize: 22,
-    lineHeight: 26,
+    fontSize: 24,
+    lineHeight: 28,
     fontWeight: "800",
     color: theme.colors.text,
   },
   sectionSubtitle: {
-    fontSize: 13,
+    marginTop: 4,
+    fontSize: 14,
     color: theme.colors.textSoft,
-    opacity: 0.8,
   },
   sectionBadge: {
     borderRadius: theme.radius.pill,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    opacity: 0.92,
-    shadowColor: theme.colors.brandDeep,
-    shadowOpacity: 0.08,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 2,
+    paddingHorizontal: 13,
+    paddingVertical: 10,
   },
   sectionBadgeText: {
     fontSize: 12,
     fontWeight: "800",
     color: theme.colors.white,
   },
-
   routeList: {
-    gap: 14,
+    gap: 12,
   },
   routeCard: {
     borderRadius: 28,
-    backgroundColor: "#FFFFFF",
+    backgroundColor: "rgba(255,252,249,0.98)",
     padding: 18,
     gap: 12,
     shadowColor: theme.colors.brandDeep,
-    shadowOpacity: 0.12,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 6,
+    shadowOpacity: 0.08,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
   },
-  routeCardFeatured: {
-    borderWidth: 1,
-    borderColor: "rgba(241,176,120,0.28)",
-    shadowOpacity: 0.16,
-  },
-  routeCardPressed: {
-    transform: [{ scale: 0.99 }],
-  },
-  featuredPill: {
-    alignSelf: "flex-start",
-    borderRadius: theme.radius.pill,
-    backgroundColor: "rgba(241,176,120,0.16)",
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    marginBottom: 2,
-  },
-  featuredPillText: {
-    fontSize: 11,
-    fontWeight: "800",
-    letterSpacing: 0.4,
-    color: theme.colors.brandDeep,
-  },
-
   routeCardTopRow: {
     flexDirection: "row",
     alignItems: "flex-start",
@@ -626,26 +613,30 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: theme.colors.text,
   },
+  routeNameInput: {
+    fontSize: 20,
+    lineHeight: 24,
+    fontWeight: "800",
+    color: theme.colors.text,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border,
+    paddingBottom: 4,
+  },
   routeMeta: {
     marginTop: 4,
-    fontSize: 13,
+    fontSize: 14,
     color: theme.colors.textSoft,
-    opacity: 0.8,
   },
-
   saveButton: {
     width: 40,
     height: 40,
     borderRadius: 14,
-    backgroundColor: "rgba(0,0,0,0.05)",
+    backgroundColor: theme.colors.surfaceSoft,
     alignItems: "center",
     justifyContent: "center",
   },
   saveButtonActive: {
-    backgroundColor: "rgba(241,176,120,0.25)",
-  },
-  saveButtonPressed: {
-    transform: [{ scale: 0.94 }],
+    backgroundColor: "rgba(241,176,120,0.2)",
   },
   saveButtonIcon: {
     fontSize: 16,
@@ -654,42 +645,6 @@ const styles = StyleSheet.create({
   saveButtonIconActive: {
     color: theme.colors.brand,
   },
-
-  infoChipRow: {
-    flexDirection: "row",
-    gap: 10,
-  },
-  infoChip: {
-    borderRadius: 18,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    flexDirection: "row",
-    gap: 6,
-    alignItems: "center",
-  },
-  safetyChip: {
-    backgroundColor: "rgba(175,203,70,0.16)",
-  },
-  crowdChip: {
-    backgroundColor: "rgba(216,229,242,0.42)",
-  },
-  infoChipLabel: {
-    fontSize: 12,
-    fontWeight: "700",
-    color: theme.colors.textSoft,
-  },
-  infoChipValue: {
-    fontSize: 12,
-    fontWeight: "800",
-    color: theme.colors.text,
-  },
-
-  divider: {
-    height: 1,
-    backgroundColor: "rgba(0,0,0,0.06)",
-    marginVertical: 2,
-  },
-
   reviewRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -697,7 +652,7 @@ const styles = StyleSheet.create({
   },
   reviewRating: {
     fontSize: 14,
-    fontWeight: "700",
+    fontWeight: "800",
     color: theme.colors.brandDeep,
   },
   reviewSnippet: {
@@ -705,7 +660,6 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     color: theme.colors.textSoft,
   },
-
   tagRow: {
     flexDirection: "row",
     flexWrap: "wrap",
@@ -713,38 +667,32 @@ const styles = StyleSheet.create({
   },
   tag: {
     borderRadius: theme.radius.pill,
-    backgroundColor: "rgba(175,203,70,0.15)",
+    backgroundColor: "#AFCB46",
     borderWidth: 1,
-    borderColor: "rgba(146,169,58,0.25)",
+    borderColor: "#92A93A",
     paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingVertical: 8,
   },
   tagText: {
     fontSize: 12,
-    fontWeight: "600",
-    color: "#4F5A22",
+    fontWeight: "700",
+    color: "#2F3615",
   },
-
   cardActions: {
     flexDirection: "row",
     gap: 10,
-    marginTop: 2,
   },
   secondaryAction: {
     flex: 1,
     borderRadius: 20,
-    backgroundColor: "rgba(0,0,0,0.04)",
+    backgroundColor: theme.colors.surfaceSoft,
     alignItems: "center",
     justifyContent: "center",
     paddingVertical: 14,
   },
-  secondaryActionPressed: {
-    transform: [{ scale: 0.98 }],
-    backgroundColor: "rgba(0,0,0,0.06)",
-  },
   secondaryActionText: {
     fontSize: 14,
-    fontWeight: "600",
+    fontWeight: "700",
     color: theme.colors.text,
   },
   primaryAction: {
@@ -754,32 +702,22 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingVertical: 14,
-    shadowColor: theme.colors.brand,
-    shadowOpacity: 0.25,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 5,
-  },
-  primaryActionPressed: {
-    transform: [{ scale: 0.98 }],
-    opacity: 0.92,
   },
   primaryActionText: {
     fontSize: 14,
     fontWeight: "800",
     color: theme.colors.white,
   },
-
   emptyState: {
     borderRadius: 28,
-    backgroundColor: "#FFFFFF",
-    padding: 24,
+    backgroundColor: "rgba(255,252,249,0.98)",
+    padding: 22,
     alignItems: "center",
     shadowColor: theme.colors.brandDeep,
-    shadowOpacity: 0.1,
-    shadowRadius: 20,
-    shadowOffset: { width: 0, height: 10 },
-    elevation: 5,
+    shadowOpacity: 0.08,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
   },
   emptyTitle: {
     fontSize: 18,
@@ -792,6 +730,5 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     textAlign: "center",
     color: theme.colors.textSoft,
-    opacity: 0.85,
   },
 });

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Feather } from "@expo/vector-icons";
+import { Feather, Ionicons } from "@expo/vector-icons";
 import {
   Modal,
   Pressable,
@@ -35,15 +35,26 @@ export type SavedRouteStartPreset = {
   safetyFeatureIds: string[];
 };
 
+export type FavoriteRouteSummary = {
+  routeId: string;
+  title: string;
+  subtitle: string;
+};
+
 type RoutesScreenProps = {
   onStartRoute: (route: SavedRouteStartPreset) => void;
   onAlertPress: () => void;
+  favoriteRouteId: string | null;
+  onFavoriteRouteChange: (route: FavoriteRouteSummary | null) => void;
 };
 
 type RouteShape = "oneWay" | "loop";
 
-const warningOrange = "#E58B5B";
-const navSlate = "#778093";
+export const defaultFavoriteRoute: FavoriteRouteSummary = {
+  routeId: "saved-morning-walk",
+  title: "River Parks Morning Walk",
+  subtitle: "Walk • 2.1 mi",
+};
 
 const routeSections: Array<{
   key: RouteSectionKey;
@@ -217,6 +228,8 @@ const savedRouteRecapDefaults: Record<
 export function RoutesScreen({
   onAlertPress,
   onStartRoute,
+  favoriteRouteId,
+  onFavoriteRouteChange,
 }: RoutesScreenProps) {
   const [searchValue, setSearchValue] = useState("");
   const [savedRouteIds, setSavedRouteIds] = useState<string[]>(
@@ -273,7 +286,12 @@ export function RoutesScreen({
       .map((section) => ({
         ...section,
         routes: (section.key === "saved"
-          ? savedRouteIds
+          ? [
+              ...(favoriteRouteId && savedRouteIds.includes(favoriteRouteId)
+                ? [favoriteRouteId]
+                : []),
+              ...savedRouteIds.filter((routeId) => routeId !== favoriteRouteId),
+            ]
               .map((routeId) => routeLookup[routeId])
               .filter((route): route is RouteItem => Boolean(route))
           : section.routes
@@ -301,7 +319,15 @@ export function RoutesScreen({
         }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue, activeQuickFilter, routeLookup, routeReviews, routeReviewTags, savedRouteIds]);
+  }, [
+    searchValue,
+    activeQuickFilter,
+    favoriteRouteId,
+    routeLookup,
+    routeReviews,
+    routeReviewTags,
+    savedRouteIds,
+  ]);
 
   const savedSection = filteredSections.find((section) => section.key === "saved");
   const otherSections = filteredSections.filter((section) => section.key !== "saved");
@@ -328,12 +354,30 @@ export function RoutesScreen({
 
   function removeFromSaved(routeId: string) {
     setSavedRouteIds((current) => current.filter((id) => id !== routeId));
+    if (favoriteRouteId === routeId) {
+      onFavoriteRouteChange(null);
+    }
     setPendingRemovalRouteId(null);
     cancelEditingRoute();
   }
 
   function requestRemoveFromSaved(routeId: string) {
     setPendingRemovalRouteId(routeId);
+  }
+
+  function toggleFavoriteRoute(route: RouteItem) {
+    if (favoriteRouteId === route.id) {
+      onFavoriteRouteChange(null);
+      setSaveToastMessage(`${route.name} removed from favorites.`);
+      return;
+    }
+
+    onFavoriteRouteChange({
+      routeId: route.id,
+      title: route.name,
+      subtitle: `Walk • ${route.distance}`,
+    });
+    setSaveToastMessage(`${route.name} added to favorites!`);
   }
 
   function toggleQuickFilter(filter: string) {
@@ -712,6 +756,65 @@ export function RoutesScreen({
                   </Text>
                 </View>
               </Pressable>
+
+              <Pressable
+                onPress={() => toggleFavoriteRoute(selectedRoute)}
+                style={[
+                  styles.favoriteEntryCard,
+                  favoriteRouteId === selectedRoute.id && styles.favoriteEntryCardActive,
+                ]}
+              >
+                <View style={styles.favoriteEntryIconWrap}>
+                  <Feather
+                    name="star"
+                    size={18}
+                    color={
+                      favoriteRouteId === selectedRoute.id
+                        ? theme.colors.white
+                        : theme.colors.brandDeep
+                    }
+                  />
+                </View>
+                <View style={styles.favoriteEntryCopy}>
+                  <Text
+                    style={[
+                      styles.favoriteEntryLabel,
+                      favoriteRouteId === selectedRoute.id &&
+                        styles.favoriteEntryLabelActive,
+                    ]}
+                  >
+                    Favorite
+                  </Text>
+                  <Text
+                    style={[
+                      styles.favoriteEntryValue,
+                      favoriteRouteId === selectedRoute.id &&
+                        styles.favoriteEntryValueActive,
+                    ]}
+                  >
+                    {favoriteRouteId === selectedRoute.id
+                      ? "This route appears in your Home favorites card."
+                      : "Add this route to favorites"}
+                  </Text>
+                </View>
+                <View
+                  style={[
+                    styles.favoriteEntryActionPill,
+                    favoriteRouteId === selectedRoute.id &&
+                      styles.favoriteEntryActionPillActive,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.favoriteEntryAction,
+                      favoriteRouteId === selectedRoute.id &&
+                        styles.favoriteEntryActionActive,
+                    ]}
+                  >
+                    {favoriteRouteId === selectedRoute.id ? "Unfavorite" : "Favorite"}
+                  </Text>
+                </View>
+              </Pressable>
             </View>
           </View>
         ) : null}
@@ -752,8 +855,8 @@ export function RoutesScreen({
                       onPress={() => setEditingRatingValue(star)}
                       style={styles.reviewStarButton}
                     >
-                      <Feather
-                        name="star"
+                      <Ionicons
+                        name={selected ? "star" : "star-outline"}
                         size={20}
                         color={selected ? theme.colors.brandDeep : "rgba(110,95,86,0.35)"}
                       />
@@ -1397,11 +1500,11 @@ const styles = StyleSheet.create({
   },
   reviewEntryCard: {
     borderRadius: 22,
-    backgroundColor: theme.colors.surfaceOrange,
+    backgroundColor: theme.colors.surfaceOrangeDeep,
     paddingHorizontal: 14,
     paddingVertical: 15,
     borderWidth: 1,
-    borderColor: "rgba(202,116,73,0.18)",
+    borderColor: theme.colors.brandDeep,
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
@@ -1416,7 +1519,7 @@ const styles = StyleSheet.create({
     width: 42,
     height: 42,
     borderRadius: 14,
-    backgroundColor: theme.colors.surfaceOrangeDeep,
+    backgroundColor: theme.colors.surfaceOrange,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -1427,7 +1530,7 @@ const styles = StyleSheet.create({
   reviewEntryLabel: {
     fontSize: 13,
     fontWeight: "800",
-    color: "#7D543B",
+    color: theme.colors.white,
     textTransform: "uppercase",
     letterSpacing: 0.4,
   },
@@ -1435,13 +1538,13 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 21,
     fontWeight: "700",
-    color: theme.colors.text,
+    color: theme.colors.white,
   },
   reviewEntryActionPill: {
     borderRadius: theme.radius.pill,
-    backgroundColor: "rgba(255,249,244,0.96)",
+    backgroundColor: theme.colors.surface,
     borderWidth: 1,
-    borderColor: "rgba(202,116,73,0.18)",
+    borderColor: theme.colors.brandDeep,
     paddingHorizontal: 13,
     paddingVertical: 10,
     alignItems: "center",
@@ -1450,6 +1553,80 @@ const styles = StyleSheet.create({
   reviewEntryAction: {
     fontSize: 13,
     fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  favoriteEntryCard: {
+    borderRadius: 22,
+    backgroundColor: theme.colors.surfaceSoft,
+    paddingHorizontal: 14,
+    paddingVertical: 15,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.12,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  favoriteEntryCardActive: {
+    backgroundColor: theme.colors.surfaceTint,
+    borderColor: theme.colors.brandDeep,
+  },
+  favoriteEntryIconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: 14,
+    backgroundColor: theme.colors.surfaceOrangeDeep,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  favoriteEntryCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  favoriteEntryLabel: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  favoriteEntryLabelActive: {
+    color: theme.colors.brandDeep,
+  },
+  favoriteEntryValue: {
+    fontSize: 15,
+    lineHeight: 21,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  favoriteEntryValueActive: {
+    color: theme.colors.text,
+  },
+  favoriteEntryActionPill: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.brandDeep,
+    paddingHorizontal: 13,
+    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  favoriteEntryActionPillActive: {
+    backgroundColor: theme.colors.surfaceWarm,
+    borderColor: theme.colors.brand,
+  },
+  favoriteEntryAction: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  favoriteEntryActionActive: {
     color: theme.colors.brandDeep,
   },
   removeConfirmOverlay: {
@@ -1566,7 +1743,9 @@ const styles = StyleSheet.create({
     color: theme.colors.textSoft,
   },
   reviewModalActions: {
+    flexDirection: "row",
     alignItems: "center",
+    gap: 10,
     marginTop: 2,
   },
   reviewInput: {

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import {
+  Modal,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -27,6 +28,8 @@ type RoutesScreenProps = {
   onStartRoute: () => void;
   onAlertPress: () => void;
 };
+
+type RouteShape = "oneWay" | "loop";
 
 const routeSections: Array<{
   key: RouteSectionKey;
@@ -152,6 +155,47 @@ const sectionAccent: Record<RouteSectionKey, [string, string]> = {
 };
 
 const quickFilters = ["Well Lit", "Low Traffic", "Nearby", "Popular"] as const;
+const availableRouteTags = [
+  "Well Lit",
+  "Low Traffic",
+  "Busy Area",
+  "Scenic",
+  "Nearby",
+  "Quick Route",
+  "Easy Pace",
+  "Moderate Crowd",
+  "Open Views",
+  "Smooth Path",
+  "Trusted",
+  "Easy Navigation",
+  "Daytime Friendly",
+  "Evening Friendly",
+  "Family Friendly",
+  "Stroller Friendly",
+  "Landmark Rich",
+  "Park Access",
+  "Sidewalk Route",
+  "Loop Route",
+] as const;
+const savedRouteRecapDefaults: Record<
+  string,
+  {
+    routeShape: RouteShape;
+    safetySettingCount: number;
+    journeyMode: "Solo" | "Group";
+  }
+> = {
+  "saved-morning-walk": {
+    routeShape: "loop",
+    safetySettingCount: 2,
+    journeyMode: "Solo",
+  },
+  "saved-park-loop": {
+    routeShape: "loop",
+    safetySettingCount: 3,
+    journeyMode: "Group",
+  },
+};
 
 export function RoutesScreen({
   onStartRoute,
@@ -162,8 +206,18 @@ export function RoutesScreen({
   );
   const [activeQuickFilter, setActiveQuickFilter] = useState<string | null>(null);
   const [routeNames, setRouteNames] = useState<Record<string, string>>({});
+  const [routeReviews, setRouteReviews] = useState<Record<string, string>>({});
+  const [routeTags, setRouteTags] = useState<Record<string, string[]>>({});
   const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
   const [editingNameValue, setEditingNameValue] = useState("");
+  const [editingReviewValue, setEditingReviewValue] = useState("");
+  const [editingTagsValue, setEditingTagsValue] = useState<string[]>([]);
+  const [isTagPickerOpen, setIsTagPickerOpen] = useState(false);
+  const [editingRouteShapeValue, setEditingRouteShapeValue] =
+    useState<RouteShape>("oneWay");
+  const [editingSafetySettingsValue, setEditingSafetySettingsValue] = useState<string[]>([]);
+  const [editingGroupJourneyValue, setEditingGroupJourneyValue] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
 
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
@@ -179,29 +233,37 @@ export function RoutesScreen({
         ...section,
         routes: section.routes.filter((route) => {
           const routeName = routeNames[route.id] ?? route.name;
+          const routeReview = routeReviews[route.id] ?? route.snippet;
+          const tags = routeTags[route.id] ?? route.tags;
           const searchableText = [
             routeName,
-            route.snippet,
+            routeReview,
             route.distance,
             route.time,
-            ...route.tags,
+            ...tags,
           ]
             .join(" ")
             .toLowerCase();
 
           const matchesSearch = query ? searchableText.includes(query) : true;
           const matchesQuickFilter = hasQuickFilter
-            ? route.tags.join(" ").toLowerCase().includes(quickFilter)
+            ? tags.join(" ").toLowerCase().includes(quickFilter)
             : true;
 
           return matchesSearch && matchesQuickFilter;
         }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue, activeQuickFilter, routeNames]);
+  }, [searchValue, activeQuickFilter, routeNames, routeReviews, routeTags]);
 
   const savedSection = filteredSections.find((section) => section.key === "saved");
   const otherSections = filteredSections.filter((section) => section.key !== "saved");
+  const selectedRoute =
+    editingRouteId === null
+      ? null
+      : routeSections
+          .flatMap((section) => section.routes)
+          .find((route) => route.id === editingRouteId) ?? null;
 
   function toggleSavedRoute(routeId: string) {
     setSavedRouteIds((current) =>
@@ -216,19 +278,39 @@ export function RoutesScreen({
   }
 
   function startEditingRoute(route: RouteItem) {
+    const recapDefaults = savedRouteRecapDefaults[route.id];
     setEditingRouteId(route.id);
     setEditingNameValue(routeNames[route.id] ?? route.name);
+    setEditingReviewValue(routeReviews[route.id] ?? route.snippet);
+    setEditingTagsValue(routeTags[route.id] ?? route.tags);
+    setEditingRouteShapeValue(recapDefaults?.routeShape ?? "oneWay");
+    setEditingSafetySettingsValue(
+      Array.from({ length: recapDefaults?.safetySettingCount ?? 0 }, (_, index) =>
+        `Setting ${index + 1}`,
+      ),
+    );
+    setEditingGroupJourneyValue(recapDefaults?.journeyMode === "Group");
+    setIsEditingName(false);
+    setIsTagPickerOpen(false);
   }
 
   function cancelEditingRoute() {
     setEditingRouteId(null);
     setEditingNameValue("");
+    setEditingReviewValue("");
+    setEditingTagsValue([]);
+    setEditingRouteShapeValue("oneWay");
+    setEditingSafetySettingsValue([]);
+    setEditingGroupJourneyValue(false);
+    setIsEditingName(false);
+    setIsTagPickerOpen(false);
   }
 
   function saveRouteName(route: RouteItem) {
     const trimmedName = editingNameValue.trim();
+    const trimmedReview = editingReviewValue.trim();
 
-    if (!trimmedName) {
+    if (!trimmedName || !trimmedReview || editingTagsValue.length === 0) {
       cancelEditingRoute();
       return;
     }
@@ -237,7 +319,23 @@ export function RoutesScreen({
       ...current,
       [route.id]: trimmedName,
     }));
+    setRouteReviews((current) => ({
+      ...current,
+      [route.id]: trimmedReview,
+    }));
+    setRouteTags((current) => ({
+      ...current,
+      [route.id]: editingTagsValue,
+    }));
     cancelEditingRoute();
+  }
+
+  function toggleEditingTag(tag: string) {
+    setEditingTagsValue((current) =>
+      current.includes(tag)
+        ? current.filter((currentTag) => currentTag !== tag)
+        : [...current, tag],
+    );
   }
 
   function renderSection(section: (typeof routeSections)[number]) {
@@ -271,23 +369,14 @@ export function RoutesScreen({
             const isSaved = savedRouteIds.includes(route.id);
             const canEditRoute = section.key === "saved";
             const routeName = routeNames[route.id] ?? route.name;
-            const isEditing = canEditRoute && editingRouteId === route.id;
+            const routeReview = routeReviews[route.id] ?? route.snippet;
+            const tags = routeTags[route.id] ?? route.tags;
 
             return (
               <View key={route.id} style={styles.routeCard}>
                 <View style={styles.routeCardTopRow}>
                   <View style={styles.routeCopy}>
-                    {isEditing ? (
-                      <TextInput
-                        value={editingNameValue}
-                        onChangeText={setEditingNameValue}
-                        placeholder="Rename route"
-                        placeholderTextColor={theme.colors.textMuted}
-                        style={styles.routeNameInput}
-                      />
-                    ) : (
-                      <Text style={styles.routeName}>{routeName}</Text>
-                    )}
+                    <Text style={styles.routeName}>{routeName}</Text>
                     <Text style={styles.routeMeta}>
                       {route.distance} • {route.time}
                     </Text>
@@ -315,10 +404,10 @@ export function RoutesScreen({
                     ★ {route.rating} ({route.reviews})
                   </Text>
                 </View>
-                <Text style={styles.reviewSnippet}>“{route.snippet}”</Text>
+                <Text style={styles.reviewSnippet}>“{routeReview}”</Text>
 
                 <View style={styles.tagRow}>
-                  {route.tags.map((tag) => (
+                  {tags.map((tag) => (
                     <View key={tag} style={styles.tag}>
                       <Text style={styles.tagText}>{tag}</Text>
                     </View>
@@ -326,43 +415,24 @@ export function RoutesScreen({
                 </View>
 
                 <View style={styles.cardActions}>
-                  {isEditing ? (
-                    <>
-                      <Pressable
-                        onPress={cancelEditingRoute}
-                        style={styles.secondaryAction}
-                      >
-                        <Text style={styles.secondaryActionText}>Cancel</Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={() => saveRouteName(route)}
-                        style={styles.primaryAction}
-                      >
-                        <Text style={styles.primaryActionText}>Save Name</Text>
-                      </Pressable>
-                    </>
-                  ) : (
-                    <>
-                      <Pressable
-                        onPress={() =>
-                          canEditRoute
-                            ? startEditingRoute(route)
-                            : toggleSavedRoute(route.id)
-                        }
-                        style={styles.secondaryAction}
-                      >
-                        <Text style={styles.secondaryActionText}>
-                          {canEditRoute ? "Edit" : isSaved ? "Saved" : "Save"}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        onPress={onStartRoute}
-                        style={styles.primaryAction}
-                      >
-                        <Text style={styles.primaryActionText}>Start Route</Text>
-                      </Pressable>
-                    </>
-                  )}
+                  <Pressable
+                    onPress={() =>
+                      canEditRoute
+                        ? startEditingRoute(route)
+                        : toggleSavedRoute(route.id)
+                    }
+                    style={styles.secondaryAction}
+                  >
+                    <Text style={styles.secondaryActionText}>
+                      {canEditRoute ? "Edit" : isSaved ? "Saved" : "Save"}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={onStartRoute}
+                    style={styles.primaryAction}
+                  >
+                    <Text style={styles.primaryActionText}>Start Route</Text>
+                  </Pressable>
                 </View>
               </View>
             );
@@ -451,6 +521,182 @@ export function RoutesScreen({
           </View>
         ) : null}
       </ScrollView>
+
+      <Modal
+        visible={selectedRoute !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={cancelEditingRoute}
+      >
+        {selectedRoute ? (
+          <View style={styles.modalOverlay}>
+            <View style={styles.modalCard}>
+              <View style={styles.modalHeader}>
+                <View style={styles.modalHeaderCopy}>
+                  <Text style={styles.modalEyebrow}>Saved Route Details</Text>
+                  {isEditingName ? (
+                    <TextInput
+                      value={editingNameValue}
+                      onChangeText={setEditingNameValue}
+                      placeholder="Route name"
+                      placeholderTextColor={theme.colors.textMuted}
+                      style={styles.modalTitleInput}
+                      autoFocus
+                    />
+                  ) : (
+                    <Text style={styles.modalTitle}>
+                      {routeNames[selectedRoute.id] ?? selectedRoute.name}
+                    </Text>
+                  )}
+                </View>
+                <Pressable
+                  onPress={cancelEditingRoute}
+                  style={styles.modalCloseButton}
+                >
+                  <Text style={styles.modalCloseText}>×</Text>
+                </Pressable>
+              </View>
+
+              <View style={styles.modalMetaRow}>
+                <View style={styles.modalMetaChip}>
+                  <Text style={styles.modalMetaLabel}>Distance</Text>
+                  <Text style={styles.modalMetaValue}>{selectedRoute.distance}</Text>
+                </View>
+                <View style={styles.modalMetaChip}>
+                  <Text style={styles.modalMetaLabel}>Time</Text>
+                  <Text style={styles.modalMetaValue}>{selectedRoute.time}</Text>
+                </View>
+                <View style={styles.modalMetaChip}>
+                  <Text style={styles.modalMetaLabel}>Route Shape</Text>
+                  <Text style={styles.modalMetaValue}>
+                    {editingRouteShapeValue === "loop" ? "Loop" : "One-way"}
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.modalSummaryRow}>
+                <View style={styles.modalSummaryChip}>
+                  <Text style={styles.modalSummaryValue}>
+                    {editingSafetySettingsValue.length}/4
+                  </Text>
+                  <Text style={styles.modalSummaryLabel}>Safety settings</Text>
+                </View>
+                <View style={styles.modalSummaryChip}>
+                  <Text style={styles.modalSummaryValue}>
+                    {editingGroupJourneyValue ? "Group" : "Solo"}
+                  </Text>
+                  <Text style={styles.modalSummaryLabel}>Journey setup</Text>
+                </View>
+                <View style={styles.modalSummaryChip}>
+                  <Text style={styles.modalSummaryValue}>
+                    {savedRouteIds.includes(selectedRoute.id) ? "Saved" : "Not saved"}
+                  </Text>
+                  <Text style={styles.modalSummaryLabel}>Favorite</Text>
+                </View>
+              </View>
+
+              <View style={styles.modalSection}>
+                <Text style={styles.modalSectionTitle}>Review Summary</Text>
+                <Text style={styles.modalReviewRating}>
+                  ★ {selectedRoute.rating} ({selectedRoute.reviews})
+                </Text>
+                <TextInput
+                  value={editingReviewValue}
+                  onChangeText={setEditingReviewValue}
+                  placeholder="Update your review"
+                  placeholderTextColor={theme.colors.textMuted}
+                  style={styles.reviewInput}
+                  multiline
+                  textAlignVertical="top"
+                />
+              </View>
+
+              <View style={styles.modalSection}>
+                <Text style={styles.modalSectionTitle}>Route Tags</Text>
+                <Text style={styles.modalHelperText}>
+                  Choose the tags that best describe this saved route.
+                </Text>
+                <Pressable
+                  onPress={() => setIsTagPickerOpen((current) => !current)}
+                  style={styles.tagDropdownButton}
+                >
+                  <Text style={styles.tagDropdownButtonText}>
+                    {isTagPickerOpen ? "Hide tag options" : "Choose route tags"}
+                  </Text>
+                  <Text style={styles.tagDropdownChevron}>
+                    {isTagPickerOpen ? "⌃" : "⌄"}
+                  </Text>
+                </Pressable>
+                {isTagPickerOpen ? (
+                  <ScrollView
+                    style={styles.modalTagList}
+                    nestedScrollEnabled
+                    showsVerticalScrollIndicator={false}
+                  >
+                    {availableRouteTags.map((tag) => {
+                      const selected = editingTagsValue.includes(tag);
+
+                      return (
+                        <Pressable
+                          key={tag}
+                          onPress={() => toggleEditingTag(tag)}
+                          style={[
+                            styles.modalTagListItem,
+                            selected && styles.modalTagListItemSelected,
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.modalTagListItemText,
+                              selected && styles.modalTagListItemTextSelected,
+                            ]}
+                          >
+                            {tag}
+                          </Text>
+                          <Text
+                            style={[
+                              styles.modalTagListItemCheck,
+                              selected && styles.modalTagListItemCheckSelected,
+                            ]}
+                          >
+                            {selected ? "Selected" : "Add"}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </ScrollView>
+                ) : null}
+                {!isTagPickerOpen ? (
+                  <View style={styles.tagRow}>
+                    {editingTagsValue.map((tag) => (
+                      <View key={tag} style={styles.tag}>
+                        <Text style={styles.tagText}>{tag}</Text>
+                      </View>
+                    ))}
+                  </View>
+                ) : null}
+              </View>
+
+              <View style={styles.modalActions}>
+                <Pressable
+                  onPress={() => setIsEditingName((current) => !current)}
+                  style={styles.secondaryAction}
+                >
+                  <Text style={styles.secondaryActionText}>
+                    {isEditingName ? "Done" : "Edit"}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => saveRouteName(selectedRoute)}
+                  style={styles.primaryAction}
+                >
+                  <Text style={styles.primaryActionText}>Save Changes</Text>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        ) : null}
+      </Modal>
     </LinearGradient>
   );
 }
@@ -614,13 +860,16 @@ const styles = StyleSheet.create({
     color: theme.colors.text,
   },
   routeNameInput: {
-    fontSize: 20,
-    lineHeight: 24,
-    fontWeight: "800",
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "700",
     color: theme.colors.text,
+    borderRadius: 18,
+    backgroundColor: "rgba(255,250,247,0.96)",
+    paddingHorizontal: 14,
+    paddingVertical: 14,
     borderBottomWidth: 1,
     borderBottomColor: theme.colors.border,
-    paddingBottom: 4,
   },
   routeMeta: {
     marginTop: 4,
@@ -707,6 +956,227 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: "800",
     color: theme.colors.white,
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: "center",
+    paddingHorizontal: 24,
+    backgroundColor: "rgba(78,67,68,0.34)",
+  },
+  modalCard: {
+    borderRadius: 30,
+    backgroundColor: "#FFFDFB",
+    padding: 24,
+    gap: 16,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.14,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 6,
+  },
+  modalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  modalHeaderCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  modalEyebrow: {
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: theme.colors.textSoft,
+  },
+  modalTitle: {
+    fontSize: 28,
+    lineHeight: 32,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  modalTitleInput: {
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: "#D8C0B0",
+    fontSize: 24,
+    lineHeight: 28,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  modalCloseButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.surfaceSoft,
+  },
+  modalCloseText: {
+    fontSize: 20,
+    lineHeight: 22,
+    color: theme.colors.textSoft,
+  },
+  modalMetaRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  modalMetaChip: {
+    flex: 1,
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: "#DFCABC",
+  },
+  modalMetaLabel: {
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 0.7,
+    textTransform: "uppercase",
+    color: theme.colors.textSoft,
+  },
+  modalMetaValue: {
+    marginTop: 6,
+    fontSize: 15,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  modalSummaryRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  modalSummaryChip: {
+    flex: 1,
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: "#DFCABC",
+    alignItems: "center",
+  },
+  modalSummaryValue: {
+    fontSize: 17,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  modalSummaryLabel: {
+    marginTop: 4,
+    fontSize: 12,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    textAlign: "center",
+    color: theme.colors.textSoft,
+  },
+  modalSection: {
+    gap: 10,
+    borderRadius: 22,
+    backgroundColor: "rgba(247,240,234,0.78)",
+    padding: 14,
+    borderWidth: 1,
+    borderColor: "rgba(223,202,188,0.9)",
+  },
+  modalSectionTitle: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  modalReviewRating: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  reviewInput: {
+    minHeight: 96,
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: "#D8C0B0",
+    fontSize: 15,
+    lineHeight: 22,
+    color: theme.colors.text,
+  },
+  modalHelperText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#625556",
+  },
+  tagDropdownButton: {
+    borderRadius: 18,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#D8C0B0",
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  tagDropdownButtonText: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  tagDropdownChevron: {
+    fontSize: 16,
+    color: theme.colors.textSoft,
+  },
+  modalTagList: {
+    maxHeight: 220,
+    borderRadius: 20,
+    overflow: "hidden",
+    borderWidth: 1,
+    borderColor: "#D8C0B0",
+    backgroundColor: "#FFFFFF",
+  },
+  modalTagListItem: {
+    paddingHorizontal: 14,
+    paddingVertical: 15,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(78,67,68,0.08)",
+  },
+  modalTagListItemSelected: {
+    backgroundColor: "#AFCB46",
+  },
+  modalTagListItemText: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  modalTagListItemCheck: {
+    fontSize: 11,
+    fontWeight: "800",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+  },
+  modalTagListItemCheckSelected: {
+    color: "#2F3615",
+  },
+  modalTagListItemTextSelected: {
+    color: "#2F3615",
+  },
+  modalText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
+  },
+  modalActions: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 4,
   },
   emptyState: {
     borderRadius: 28,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -21,6 +21,8 @@ type RouteItem = {
   reviews: string;
   snippet: string;
   tags: string[];
+  safetyScore: string;
+  crowdLevel: string;
 };
 
 type RoutesScreenProps = {
@@ -48,6 +50,8 @@ const routeSections: Array<{
         reviews: "18 reviews",
         snippet: "Easy to follow and feels calm before work.",
         tags: ["Well Lit", "Low Traffic", "Easy Pace"],
+        safetyScore: "High",
+        crowdLevel: "Light",
       },
       {
         id: "saved-park-loop",
@@ -58,6 +62,8 @@ const routeSections: Array<{
         reviews: "26 reviews",
         snippet: "Open paths and lots of visibility the whole way.",
         tags: ["Open Views", "Popular", "Moderate Crowd"],
+        safetyScore: "High",
+        crowdLevel: "Moderate",
       },
     ],
   },
@@ -75,6 +81,8 @@ const routeSections: Array<{
         reviews: "32 reviews",
         snippet: "Well lit and great for evening walks.",
         tags: ["Well Lit", "Moderate Crowd", "Smooth Path"],
+        safetyScore: "High",
+        crowdLevel: "Moderate",
       },
       {
         id: "popular-downtown",
@@ -85,6 +93,8 @@ const routeSections: Array<{
         reviews: "24 reviews",
         snippet: "Busy enough to feel comfortable but still easy to pace.",
         tags: ["Busy Area", "Shops Nearby", "Quick Route"],
+        safetyScore: "Medium",
+        crowdLevel: "Busy",
       },
     ],
   },
@@ -102,6 +112,8 @@ const routeSections: Array<{
         reviews: "41 reviews",
         snippet: "Feels safe even after sunset because the lighting is consistent.",
         tags: ["Well Lit", "Trusted", "Low Traffic"],
+        safetyScore: "High",
+        crowdLevel: "Light",
       },
       {
         id: "reviewed-campus",
@@ -112,6 +124,8 @@ const routeSections: Array<{
         reviews: "29 reviews",
         snippet: "A good mix of visibility, people around, and easy landmarks.",
         tags: ["Landmarks", "Moderate Crowd", "Easy Navigation"],
+        safetyScore: "High",
+        crowdLevel: "Moderate",
       },
     ],
   },
@@ -129,6 +143,8 @@ const routeSections: Array<{
         reviews: "15 reviews",
         snippet: "Short, scenic, and simple when you want something close.",
         tags: ["Nearby", "Scenic", "Light Traffic"],
+        safetyScore: "Medium",
+        crowdLevel: "Light",
       },
       {
         id: "nearby-market",
@@ -139,6 +155,8 @@ const routeSections: Array<{
         reviews: "12 reviews",
         snippet: "Useful for quick daytime walks with plenty of activity nearby.",
         tags: ["Daytime", "Busy Area", "Quick Route"],
+        safetyScore: "Medium",
+        crowdLevel: "Busy",
       },
     ],
   },
@@ -182,6 +200,8 @@ export function RoutesScreen({
             route.snippet,
             route.distance,
             route.time,
+            route.safetyScore,
+            route.crowdLevel,
             ...route.tags,
           ]
             .join(" ")
@@ -222,7 +242,6 @@ export function RoutesScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
-        {/* PAGE HEADER */}
         <View style={styles.pageIntro}>
           <Text style={styles.pageEyebrow}>Explore</Text>
           <Text style={styles.pageTitle}>Routes</Text>
@@ -231,7 +250,6 @@ export function RoutesScreen({
           </Text>
         </View>
 
-        {/* SEARCH */}
         <Pressable
           style={({ pressed }) => [
             styles.searchShell,
@@ -248,7 +266,6 @@ export function RoutesScreen({
           />
         </Pressable>
 
-        {/* QUICK FILTERS */}
         <View style={styles.filterRow}>
           {quickFilters.map((filter) => {
             const selected = activeQuickFilter === filter;
@@ -348,6 +365,19 @@ export function RoutesScreen({
                         </Text>
                       </Pressable>
                     </View>
+
+                    <View style={styles.infoChipRow}>
+                      <View style={[styles.infoChip, styles.safetyChip]}>
+                        <Text style={styles.infoChipLabel}>Safety</Text>
+                        <Text style={styles.infoChipValue}>{route.safetyScore}</Text>
+                      </View>
+                      <View style={[styles.infoChip, styles.crowdChip]}>
+                        <Text style={styles.infoChipLabel}>Crowd</Text>
+                        <Text style={styles.infoChipValue}>{route.crowdLevel}</Text>
+                      </View>
+                    </View>
+
+                    <View style={styles.divider} />
 
                     <View style={styles.reviewRow}>
                       <Text style={styles.reviewRating}>
@@ -623,6 +653,41 @@ const styles = StyleSheet.create({
   },
   saveButtonIconActive: {
     color: theme.colors.brand,
+  },
+
+  infoChipRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  infoChip: {
+    borderRadius: 18,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    flexDirection: "row",
+    gap: 6,
+    alignItems: "center",
+  },
+  safetyChip: {
+    backgroundColor: "rgba(175,203,70,0.16)",
+  },
+  crowdChip: {
+    backgroundColor: "rgba(216,229,242,0.42)",
+  },
+  infoChipLabel: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+  },
+  infoChipValue: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+
+  divider: {
+    height: 1,
+    backgroundColor: "rgba(0,0,0,0.06)",
+    marginVertical: 2,
   },
 
   reviewRow: {

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -34,7 +34,114 @@ const routeSections: Array<{
   subtitle: string;
   routes: RouteItem[];
 }> = [
-  // all the saved / popular / reviewed / nearby route data
+  {
+    key: "saved",
+    title: "Saved Routes",
+    subtitle: "Your go-to paths",
+    routes: [
+      {
+        id: "saved-morning-walk",
+        name: "Morning Walk",
+        distance: "2.1 mi",
+        time: "42 min",
+        rating: "4.8",
+        reviews: "18 reviews",
+        snippet: "Easy to follow and feels calm before work.",
+        tags: ["Well Lit", "Low Traffic", "Easy Pace"],
+      },
+      {
+        id: "saved-park-loop",
+        name: "Park Loop",
+        distance: "3.0 mi",
+        time: "58 min",
+        rating: "4.7",
+        reviews: "26 reviews",
+        snippet: "Open paths and lots of visibility the whole way.",
+        tags: ["Open Views", "Popular", "Moderate Crowd"],
+      },
+    ],
+  },
+  {
+    key: "popular",
+    title: "Popular Routes",
+    subtitle: "Quick picks people love",
+    routes: [
+      {
+        id: "popular-riverwalk",
+        name: "Riverwalk Loop",
+        distance: "2.8 mi",
+        time: "51 min",
+        rating: "4.6",
+        reviews: "32 reviews",
+        snippet: "Well lit and great for evening walks.",
+        tags: ["Well Lit", "Moderate Crowd", "Smooth Path"],
+      },
+      {
+        id: "popular-downtown",
+        name: "Downtown Out-and-Back",
+        distance: "1.9 mi",
+        time: "36 min",
+        rating: "4.5",
+        reviews: "24 reviews",
+        snippet: "Busy enough to feel comfortable but still easy to pace.",
+        tags: ["Busy Area", "Shops Nearby", "Quick Route"],
+      },
+    ],
+  },
+  {
+    key: "reviewed",
+    title: "Reviewed Routes",
+    subtitle: "Most trusted by the community",
+    routes: [
+      {
+        id: "reviewed-greenway",
+        name: "Greenway Path",
+        distance: "4.2 mi",
+        time: "1 hr 12 min",
+        rating: "4.9",
+        reviews: "41 reviews",
+        snippet: "Feels safe even after sunset because the lighting is consistent.",
+        tags: ["Well Lit", "Trusted", "Low Traffic"],
+      },
+      {
+        id: "reviewed-campus",
+        name: "Campus Connector",
+        distance: "2.4 mi",
+        time: "44 min",
+        rating: "4.7",
+        reviews: "29 reviews",
+        snippet: "A good mix of visibility, people around, and easy landmarks.",
+        tags: ["Landmarks", "Moderate Crowd", "Easy Navigation"],
+      },
+    ],
+  },
+  {
+    key: "nearby",
+    title: "Nearby Routes",
+    subtitle: "Good options close to you",
+    routes: [
+      {
+        id: "nearby-lake",
+        name: "Lakeside Route",
+        distance: "1.6 mi",
+        time: "31 min",
+        rating: "4.4",
+        reviews: "15 reviews",
+        snippet: "Short, scenic, and simple when you want something close.",
+        tags: ["Nearby", "Scenic", "Light Traffic"],
+      },
+      {
+        id: "nearby-market",
+        name: "Market Street Loop",
+        distance: "2.0 mi",
+        time: "38 min",
+        rating: "4.3",
+        reviews: "12 reviews",
+        snippet: "Useful for quick daytime walks with plenty of activity nearby.",
+        tags: ["Daytime", "Busy Area", "Quick Route"],
+      },
+    ],
+  },
 ];
 
 const sectionAccent: Record<RouteSectionKey, [string, string]> = {
@@ -55,7 +162,9 @@ export function RoutesScreen({
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
 
-    if (!query) return routeSections;
+    if (!query) {
+      return routeSections;
+    }
 
     return routeSections
       .map((section) => ({
@@ -87,12 +196,16 @@ export function RoutesScreen({
   return (
     <LinearGradient
       colors={[theme.colors.background, "#F2E8DD", theme.colors.backgroundDeep]}
+      locations={[0, 0.48, 1]}
+      start={{ x: 0.5, y: 0 }}
+      end={{ x: 0.5, y: 1 }}
       style={styles.screen}
     >
-      <ScrollView contentContainerStyle={styles.content}>
-        
-        {/* SEARCH */}
-        <View style={styles.searchShell}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Pressable style={({ pressed }) => [styles.searchShell, pressed && styles.searchShellPressed]}>
           <Text style={styles.searchIcon}>⌕</Text>
           <TextInput
             value={searchValue}
@@ -101,43 +214,45 @@ export function RoutesScreen({
             placeholderTextColor={theme.colors.textMuted}
             style={styles.searchInput}
           />
-        </View>
+        </Pressable>
 
-        {/* SECTIONS */}
         {filteredSections.map((section) => (
           <View key={section.key} style={styles.section}>
-            
-            {/* HEADER */}
             <View style={styles.sectionHeader}>
               <View>
                 <Text style={styles.sectionTitle}>{section.title}</Text>
                 <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
               </View>
-
               <LinearGradient
                 colors={sectionAccent[section.key]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
                 style={styles.sectionBadge}
               >
                 <Text style={styles.sectionBadgeText}>
                   {section.key === "reviewed"
                     ? "Top rated"
                     : section.key === "nearby"
-                    ? "Near you"
-                    : section.key === "saved"
-                    ? "Personal"
-                    : "Trending"}
+                      ? "Near you"
+                      : section.key === "saved"
+                        ? "Personal"
+                        : "Trending"}
                 </Text>
               </LinearGradient>
             </View>
 
-            {/* ROUTES */}
             <View style={styles.routeList}>
               {section.routes.map((route) => {
                 const isSaved = savedRouteIds.includes(route.id);
 
                 return (
-                  <View key={route.id} style={styles.routeCard}>
-                    
+                  <Pressable
+                    key={route.id}
+                    style={({ pressed }) => [
+                      styles.routeCard,
+                      pressed && styles.routeCardPressed,
+                    ]}
+                  >
                     <View style={styles.routeCardTopRow}>
                       <View style={styles.routeCopy}>
                         <Text style={styles.routeName}>{route.name}</Text>
@@ -148,9 +263,10 @@ export function RoutesScreen({
 
                       <Pressable
                         onPress={() => toggleSavedRoute(route.id)}
-                        style={[
+                        style={({ pressed }) => [
                           styles.saveButton,
                           isSaved && styles.saveButtonActive,
+                          pressed && styles.saveButtonPressed,
                         ]}
                       >
                         <Text
@@ -164,13 +280,13 @@ export function RoutesScreen({
                       </Pressable>
                     </View>
 
-                    <Text style={styles.reviewRating}>
-                      ★ {route.rating} ({route.reviews})
-                    </Text>
+                    <View style={styles.reviewRow}>
+                      <Text style={styles.reviewRating}>
+                        ★ {route.rating} ({route.reviews})
+                      </Text>
+                    </View>
 
-                    <Text style={styles.reviewSnippet}>
-                      “{route.snippet}”
-                    </Text>
+                    <Text style={styles.reviewSnippet}>“{route.snippet}”</Text>
 
                     <View style={styles.tagRow}>
                       {route.tags.map((tag) => (
@@ -181,7 +297,13 @@ export function RoutesScreen({
                     </View>
 
                     <View style={styles.cardActions}>
-                      <Pressable style={styles.secondaryAction}>
+                      <Pressable
+                        onPress={() => toggleSavedRoute(route.id)}
+                        style={({ pressed }) => [
+                          styles.secondaryAction,
+                          pressed && styles.secondaryActionPressed,
+                        ]}
+                      >
                         <Text style={styles.secondaryActionText}>
                           {isSaved ? "Saved" : "Save"}
                         </Text>
@@ -189,35 +311,45 @@ export function RoutesScreen({
 
                       <Pressable
                         onPress={onStartRoute}
-                        style={styles.primaryAction}
+                        style={({ pressed }) => [
+                          styles.primaryAction,
+                          pressed && styles.primaryActionPressed,
+                        ]}
                       >
-                        <Text style={styles.primaryActionText}>
-                          Start Route
-                        </Text>
+                        <Text style={styles.primaryActionText}>Start Route</Text>
                       </Pressable>
                     </View>
-                  </View>
+                  </Pressable>
                 );
               })}
             </View>
           </View>
         ))}
+
+        {filteredSections.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyTitle}>No routes match that search</Text>
+            <Text style={styles.emptyText}>
+              Try a route name, neighborhood, or tag like well lit.
+            </Text>
+          </View>
+        ) : null}
       </ScrollView>
     </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  screen: { flex: 1 },
-
+  screen: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
   content: {
     paddingHorizontal: 16,
     paddingTop: 24,
     paddingBottom: 180,
     gap: 18,
   },
-
-  // SEARCH UPGRADE
   searchShell: {
     flexDirection: "row",
     alignItems: "center",
@@ -232,52 +364,53 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 10 },
     elevation: 6,
   },
-
+  searchShellPressed: {
+    transform: [{ scale: 0.995 }],
+  },
   searchIcon: {
     fontSize: 18,
     color: theme.colors.textMuted,
   },
-
   searchInput: {
     flex: 1,
     fontSize: 16,
     color: theme.colors.text,
+    paddingVertical: 0,
   },
-
-  section: { gap: 12 },
-
+  section: {
+    gap: 12,
+  },
   sectionHeader: {
     flexDirection: "row",
+    alignItems: "center",
     justifyContent: "space-between",
+    gap: 12,
   },
-
   sectionTitle: {
     fontSize: 22,
     fontWeight: "800",
     color: theme.colors.text,
   },
-
   sectionSubtitle: {
+    marginTop: 4,
     fontSize: 13,
     color: theme.colors.textSoft,
     opacity: 0.8,
   },
-
   sectionBadge: {
-    borderRadius: 20,
+    borderRadius: theme.radius.pill,
     paddingHorizontal: 12,
     paddingVertical: 8,
+    opacity: 0.92,
   },
-
   sectionBadgeText: {
     fontSize: 12,
-    fontWeight: "700",
-    color: "#fff",
+    fontWeight: "800",
+    color: theme.colors.white,
   },
-
-  routeList: { gap: 12 },
-
-  // CARD UPGRADE
+  routeList: {
+    gap: 12,
+  },
   routeCard: {
     borderRadius: 28,
     backgroundColor: "#FFFFFF",
@@ -289,26 +422,30 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 10 },
     elevation: 6,
   },
-
+  routeCardPressed: {
+    transform: [{ scale: 0.99 }],
+  },
   routeCardTopRow: {
     flexDirection: "row",
+    alignItems: "flex-start",
     justifyContent: "space-between",
+    gap: 12,
   },
-
-  routeCopy: { flex: 1 },
-
+  routeCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
   routeName: {
     fontSize: 20,
     fontWeight: "800",
     color: theme.colors.text,
   },
-
   routeMeta: {
+    marginTop: 4,
     fontSize: 13,
     color: theme.colors.textSoft,
     opacity: 0.8,
   },
-
   saveButton: {
     width: 40,
     height: 40,
@@ -317,75 +454,117 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-
   saveButtonActive: {
     backgroundColor: "rgba(241,176,120,0.25)",
   },
-
+  saveButtonPressed: {
+    transform: [{ scale: 0.94 }],
+  },
   saveButtonIcon: {
+    fontSize: 16,
     color: theme.colors.textMuted,
   },
-
   saveButtonIconActive: {
     color: theme.colors.brand,
   },
-
+  reviewRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
   reviewRating: {
+    fontSize: 14,
     fontWeight: "700",
     color: theme.colors.brandDeep,
   },
-
   reviewSnippet: {
+    fontSize: 14,
+    lineHeight: 20,
     color: theme.colors.textSoft,
   },
-
-  // TAG FIX
-  tag: {
-    backgroundColor: "rgba(175,203,70,0.15)",
-    borderRadius: 20,
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-  },
-
-  tagText: {
-    fontSize: 12,
-    color: "#4F5A22",
-  },
-
   tagRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 8,
   },
-
+  tag: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(175,203,70,0.15)",
+    borderWidth: 1,
+    borderColor: "rgba(146,169,58,0.25)",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tagText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#4F5A22",
+  },
   cardActions: {
     flexDirection: "row",
     gap: 10,
   },
-
   secondaryAction: {
     flex: 1,
     borderRadius: 20,
     backgroundColor: "rgba(0,0,0,0.04)",
-    paddingVertical: 14,
     alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 14,
   },
-
+  secondaryActionPressed: {
+    transform: [{ scale: 0.98 }],
+    backgroundColor: "rgba(0,0,0,0.06)",
+  },
+  secondaryActionText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: theme.colors.text,
+  },
   primaryAction: {
     flex: 1.3,
     borderRadius: 20,
     backgroundColor: theme.colors.brand,
-    paddingVertical: 14,
     alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 14,
+    shadowColor: theme.colors.brand,
+    shadowOpacity: 0.25,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 5,
   },
-
+  primaryActionPressed: {
+    transform: [{ scale: 0.98 }],
+    opacity: 0.92,
+  },
   primaryActionText: {
-    color: "#fff",
+    fontSize: 14,
     fontWeight: "800",
+    color: theme.colors.white,
   },
-
-  secondaryActionText: {
+  emptyState: {
+    borderRadius: 28,
+    backgroundColor: "#FFFFFF",
+    padding: 24,
+    alignItems: "center",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.1,
+    shadowRadius: 20,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 5,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: "800",
     color: theme.colors.text,
-    fontWeight: "600",
+  },
+  emptyText: {
+    marginTop: 6,
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: "center",
+    color: theme.colors.textSoft,
+    opacity: 0.85,
   },
 });

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -24,8 +24,18 @@ type RouteItem = {
   tags: string[];
 };
 
+export type SavedRouteStartPreset = {
+  routeId: string;
+  routeName: string;
+  distance: string;
+  time: string;
+  routeShape: RouteShape;
+  tags: string[];
+  safetyFeatureIds: string[];
+};
+
 type RoutesScreenProps = {
-  onStartRoute: () => void;
+  onStartRoute: (route: SavedRouteStartPreset) => void;
   onAlertPress: () => void;
 };
 
@@ -181,18 +191,18 @@ const savedRouteRecapDefaults: Record<
   string,
   {
     routeShape: RouteShape;
-    safetySettingCount: number;
+    safetyFeatureIds: string[];
     journeyMode: "Solo" | "Group";
   }
 > = {
   "saved-morning-walk": {
     routeShape: "loop",
-    safetySettingCount: 2,
+    safetyFeatureIds: ["off-route", "check-ins"],
     journeyMode: "Solo",
   },
   "saved-park-loop": {
     routeShape: "loop",
-    safetySettingCount: 3,
+    safetyFeatureIds: ["off-route", "missed-check-in", "emergency"],
     journeyMode: "Group",
   },
 };
@@ -273,6 +283,11 @@ export function RoutesScreen({
     );
   }
 
+  function removeFromSaved(routeId: string) {
+    setSavedRouteIds((current) => current.filter((id) => id !== routeId));
+    cancelEditingRoute();
+  }
+
   function toggleQuickFilter(filter: string) {
     setActiveQuickFilter((current) => (current === filter ? null : filter));
   }
@@ -284,11 +299,7 @@ export function RoutesScreen({
     setEditingReviewValue(routeReviews[route.id] ?? route.snippet);
     setEditingTagsValue(routeTags[route.id] ?? route.tags);
     setEditingRouteShapeValue(recapDefaults?.routeShape ?? "oneWay");
-    setEditingSafetySettingsValue(
-      Array.from({ length: recapDefaults?.safetySettingCount ?? 0 }, (_, index) =>
-        `Setting ${index + 1}`,
-      ),
-    );
+    setEditingSafetySettingsValue(recapDefaults?.safetyFeatureIds ?? []);
     setEditingGroupJourneyValue(recapDefaults?.journeyMode === "Group");
     setIsEditingName(false);
     setIsTagPickerOpen(false);
@@ -336,6 +347,18 @@ export function RoutesScreen({
         ? current.filter((currentTag) => currentTag !== tag)
         : [...current, tag],
     );
+  }
+
+  function buildStartPreset(route: RouteItem): SavedRouteStartPreset {
+    return {
+      routeId: route.id,
+      routeName: routeNames[route.id] ?? route.name,
+      distance: route.distance,
+      time: route.time,
+      routeShape: savedRouteRecapDefaults[route.id]?.routeShape ?? "oneWay",
+      tags: routeTags[route.id] ?? route.tags,
+      safetyFeatureIds: savedRouteRecapDefaults[route.id]?.safetyFeatureIds ?? [],
+    };
   }
 
   function renderSection(section: (typeof routeSections)[number]) {
@@ -428,7 +451,7 @@ export function RoutesScreen({
                     </Text>
                   </Pressable>
                   <Pressable
-                    onPress={onStartRoute}
+                    onPress={() => onStartRoute(buildStartPreset(route))}
                     style={styles.primaryAction}
                   >
                     <Text style={styles.primaryActionText}>Start Route</Text>
@@ -693,6 +716,12 @@ export function RoutesScreen({
                   <Text style={styles.primaryActionText}>Save Changes</Text>
                 </Pressable>
               </View>
+              <Pressable
+                onPress={() => removeFromSaved(selectedRoute.id)}
+                style={styles.removeSavedButton}
+              >
+                <Text style={styles.removeSavedButtonText}>Remove from Saved</Text>
+              </Pressable>
             </View>
           </View>
         ) : null}
@@ -953,6 +982,21 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
   },
   primaryActionText: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: theme.colors.white,
+  },
+  removeSavedButton: {
+    marginTop: 12,
+    borderRadius: 18,
+    backgroundColor: theme.colors.ink,
+    borderWidth: 1,
+    borderColor: theme.colors.ink,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 13,
+  },
+  removeSavedButtonText: {
     fontSize: 14,
     fontWeight: "800",
     color: theme.colors.white,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -205,7 +205,12 @@ export function RoutesScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
-        <Pressable style={({ pressed }) => [styles.searchShell, pressed && styles.searchShellPressed]}>
+        <Pressable
+          style={({ pressed }) => [
+            styles.searchShell,
+            pressed && styles.searchShellPressed,
+          ]}
+        >
           <Text style={styles.searchIcon}>⌕</Text>
           <TextInput
             value={searchValue}
@@ -219,10 +224,11 @@ export function RoutesScreen({
         {filteredSections.map((section) => (
           <View key={section.key} style={styles.section}>
             <View style={styles.sectionHeader}>
-              <View>
+              <View style={styles.sectionTitleWrap}>
                 <Text style={styles.sectionTitle}>{section.title}</Text>
                 <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
               </View>
+
               <LinearGradient
                 colors={sectionAccent[section.key]}
                 start={{ x: 0, y: 0 }}
@@ -242,17 +248,25 @@ export function RoutesScreen({
             </View>
 
             <View style={styles.routeList}>
-              {section.routes.map((route) => {
+              {section.routes.map((route, index) => {
                 const isSaved = savedRouteIds.includes(route.id);
+                const isFeatured = index === 0;
 
                 return (
                   <Pressable
                     key={route.id}
                     style={({ pressed }) => [
                       styles.routeCard,
+                      isFeatured && styles.routeCardFeatured,
                       pressed && styles.routeCardPressed,
                     ]}
                   >
+                    {isFeatured ? (
+                      <View style={styles.featuredPill}>
+                        <Text style={styles.featuredPillText}>Recommended</Text>
+                      </View>
+                    ) : null}
+
                     <View style={styles.routeCardTopRow}>
                       <View style={styles.routeCopy}>
                         <Text style={styles.routeName}>{route.name}</Text>
@@ -348,7 +362,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 24,
     paddingBottom: 180,
-    gap: 18,
+    gap: 22,
   },
   searchShell: {
     flexDirection: "row",
@@ -378,21 +392,26 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
   },
   section: {
-    gap: 12,
+    gap: 14,
+    paddingTop: 2,
   },
   sectionHeader: {
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "flex-end",
     justifyContent: "space-between",
     gap: 12,
   },
+  sectionTitleWrap: {
+    flex: 1,
+    gap: 4,
+  },
   sectionTitle: {
     fontSize: 22,
+    lineHeight: 26,
     fontWeight: "800",
     color: theme.colors.text,
   },
   sectionSubtitle: {
-    marginTop: 4,
     fontSize: 13,
     color: theme.colors.textSoft,
     opacity: 0.8,
@@ -402,6 +421,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     opacity: 0.92,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.08,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
   },
   sectionBadgeText: {
     fontSize: 12,
@@ -409,7 +433,7 @@ const styles = StyleSheet.create({
     color: theme.colors.white,
   },
   routeList: {
-    gap: 12,
+    gap: 14,
   },
   routeCard: {
     borderRadius: 28,
@@ -422,8 +446,27 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 10 },
     elevation: 6,
   },
+  routeCardFeatured: {
+    borderWidth: 1,
+    borderColor: "rgba(241,176,120,0.28)",
+    shadowOpacity: 0.16,
+  },
   routeCardPressed: {
     transform: [{ scale: 0.99 }],
+  },
+  featuredPill: {
+    alignSelf: "flex-start",
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(241,176,120,0.16)",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginBottom: 2,
+  },
+  featuredPillText: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+    color: theme.colors.brandDeep,
   },
   routeCardTopRow: {
     flexDirection: "row",
@@ -437,6 +480,7 @@ const styles = StyleSheet.create({
   },
   routeName: {
     fontSize: 20,
+    lineHeight: 24,
     fontWeight: "800",
     color: theme.colors.text,
   },
@@ -503,6 +547,7 @@ const styles = StyleSheet.create({
   cardActions: {
     flexDirection: "row",
     gap: 10,
+    marginTop: 2,
   },
   secondaryAction: {
     flex: 1,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -173,10 +173,10 @@ const routeSections: Array<{
 ];
 
 const sectionAccent: Record<RouteSectionKey, [string, string]> = {
-  saved: ["#F7D9C9", "#F1B08F"],
-  popular: ["#F4B37E", "#E48C57"],
-  reviewed: ["#D8E59C", "#B9CD62"],
-  nearby: ["#D8E5F2", "#B5CBE6"],
+  saved: [theme.colors.surfaceOrange, theme.colors.surfaceWarmDeep],
+  popular: [theme.colors.brandBright, theme.colors.brand],
+  reviewed: [theme.colors.accentLime, theme.colors.success],
+  nearby: [theme.colors.brandBright, theme.colors.brandBright],
 };
 
 const quickFilters = ["Well Lit", "Low Traffic", "Nearby", "Popular"] as const;
@@ -231,6 +231,14 @@ export function RoutesScreen({
   favoriteRouteId,
   onFavoriteRouteChange,
 }: RoutesScreenProps) {
+  const [expandedSections, setExpandedSections] = useState<
+    Record<RouteSectionKey, boolean>
+  >({
+    saved: true,
+    popular: false,
+    reviewed: false,
+    nearby: false,
+  });
   const [searchValue, setSearchValue] = useState("");
   const [savedRouteIds, setSavedRouteIds] = useState<string[]>(
     routeSections[0].routes.map((route) => route.id),
@@ -384,6 +392,13 @@ export function RoutesScreen({
     setActiveQuickFilter((current) => (current === filter ? null : filter));
   }
 
+  function toggleSection(sectionKey: RouteSectionKey) {
+    setExpandedSections((current) => ({
+      ...current,
+      [sectionKey]: !current[sectionKey],
+    }));
+  }
+
   function startEditingRoute(route: RouteItem) {
     const recapDefaults = savedRouteRecapDefaults[route.id];
     setEditingRouteId(route.id);
@@ -503,89 +518,107 @@ export function RoutesScreen({
   }
 
   function renderSection(section: (typeof routeSections)[number]) {
+    const isExpanded = expandedSections[section.key];
+    const headerColors = sectionAccent[section.key];
+
     return (
       <View key={section.key} style={styles.section}>
-        <View style={styles.sectionHeader}>
-          <View>
-            <Text style={styles.sectionTitle}>{section.title}</Text>
-            <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
-          </View>
-        </View>
+        <Pressable
+          onPress={() => toggleSection(section.key)}
+          style={({ pressed }) => [pressed && styles.sectionHeaderPressed]}
+        >
+          <LinearGradient
+            colors={headerColors}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
+            style={[styles.sectionHeader, styles.sectionHeaderButton]}
+          >
+            <View>
+              <Text style={styles.sectionTitle}>{section.title}</Text>
+              <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
+            </View>
+            <View style={styles.sectionChevronWrap}>
+              <Text style={styles.sectionChevron}>{isExpanded ? "⌃" : "⌄"}</Text>
+            </View>
+          </LinearGradient>
+        </Pressable>
 
-        <View style={styles.routeList}>
-          {section.routes.map((route) => {
-            const isSaved = savedRouteIds.includes(route.id);
-            const canEditRoute = section.key === "saved";
-            const routeName = route.name;
-            const routeReview = routeReviews[route.id] ?? route.snippet;
-            const tags = routeReviewTags[route.id] ?? route.tags;
+        {isExpanded ? (
+          <View style={styles.routeList}>
+            {section.routes.map((route) => {
+              const isSaved = savedRouteIds.includes(route.id);
+              const canEditRoute = section.key === "saved";
+              const routeName = route.name;
+              const routeReview = routeReviews[route.id] ?? route.snippet;
+              const tags = routeReviewTags[route.id] ?? route.tags;
 
-            return (
-              <View key={route.id} style={styles.routeCard}>
-                <View style={styles.routeCardTopRow}>
-                  <View style={styles.routeCopy}>
-                    <Text style={styles.routeName}>{routeName}</Text>
-                    <Text style={styles.routeMeta}>
-                      {route.distance} • {route.time}
-                    </Text>
-                  </View>
-                  <Pressable
-                    onPress={() => toggleSavedRoute(route)}
-                    style={[
-                      styles.saveButton,
-                      isSaved && styles.saveButtonActive,
-                    ]}
-                  >
-                    <Text
+              return (
+                <View key={route.id} style={styles.routeCard}>
+                  <View style={styles.routeCardTopRow}>
+                    <View style={styles.routeCopy}>
+                      <Text style={styles.routeName}>{routeName}</Text>
+                      <Text style={styles.routeMeta}>
+                        {route.distance} • {route.time}
+                      </Text>
+                    </View>
+                    <Pressable
+                      onPress={() => toggleSavedRoute(route)}
                       style={[
-                        styles.saveButtonIcon,
-                        isSaved && styles.saveButtonIconActive,
+                        styles.saveButton,
+                        isSaved && styles.saveButtonActive,
                       ]}
                     >
-                      ♥
+                      <Text
+                        style={[
+                          styles.saveButtonIcon,
+                          isSaved && styles.saveButtonIconActive,
+                        ]}
+                      >
+                        ♥
+                      </Text>
+                    </Pressable>
+                  </View>
+
+                  <View style={styles.reviewRow}>
+                    <Text style={styles.reviewRating}>
+                      ★ {route.rating} ({route.reviews})
                     </Text>
-                  </Pressable>
-                </View>
+                  </View>
+                  <Text style={styles.reviewSnippet}>“{routeReview}”</Text>
 
-                <View style={styles.reviewRow}>
-                  <Text style={styles.reviewRating}>
-                    ★ {route.rating} ({route.reviews})
-                  </Text>
-                </View>
-                <Text style={styles.reviewSnippet}>“{routeReview}”</Text>
+                  <View style={styles.tagRow}>
+                    {tags.map((tag) => (
+                      <View key={tag} style={styles.tag}>
+                        <Text style={styles.tagText}>{tag}</Text>
+                      </View>
+                    ))}
+                  </View>
 
-                <View style={styles.tagRow}>
-                  {tags.map((tag) => (
-                    <View key={tag} style={styles.tag}>
-                      <Text style={styles.tagText}>{tag}</Text>
-                    </View>
-                  ))}
+                  <View style={styles.cardActions}>
+                    <Pressable
+                      onPress={() =>
+                        canEditRoute
+                          ? startEditingRoute(route)
+                          : toggleSavedRoute(route)
+                      }
+                      style={styles.secondaryAction}
+                    >
+                      <Text style={styles.secondaryActionText}>
+                        {canEditRoute ? "View" : isSaved ? "Saved" : "Save"}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => onStartRoute(buildStartPreset(route))}
+                      style={styles.primaryAction}
+                    >
+                      <Text style={styles.primaryActionText}>Start Route</Text>
+                    </Pressable>
+                  </View>
                 </View>
-
-                <View style={styles.cardActions}>
-                  <Pressable
-                    onPress={() =>
-                      canEditRoute
-                        ? startEditingRoute(route)
-                        : toggleSavedRoute(route)
-                    }
-                    style={styles.secondaryAction}
-                  >
-                    <Text style={styles.secondaryActionText}>
-                      {canEditRoute ? "View" : isSaved ? "Saved" : "Save"}
-                    </Text>
-                  </Pressable>
-                  <Pressable
-                    onPress={() => onStartRoute(buildStartPreset(route))}
-                    style={styles.primaryAction}
-                  >
-                    <Text style={styles.primaryActionText}>Start Route</Text>
-                  </Pressable>
-                </View>
-              </View>
-            );
-          })}
-        </View>
+              );
+            })}
+          </View>
+        ) : null}
       </View>
     );
   }
@@ -1170,6 +1203,19 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     gap: 12,
   },
+  sectionHeaderButton: {
+    borderRadius: 24,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.06,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 2,
+  },
+  sectionHeaderPressed: {
+    opacity: 0.92,
+  },
   sectionTitle: {
     fontSize: 24,
     lineHeight: 28,
@@ -1179,7 +1225,20 @@ const styles = StyleSheet.create({
   sectionSubtitle: {
     marginTop: 4,
     fontSize: 14,
-    color: theme.colors.textSoft,
+    color: theme.colors.text,
+  },
+  sectionChevronWrap: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: theme.colors.surface,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sectionChevron: {
+    fontSize: 18,
+    color: theme.colors.brandDeep,
+    fontWeight: "800",
   },
   routeList: {
     gap: 12,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Feather } from "@expo/vector-icons";
 import {
   Modal,
   Pressable,
@@ -40,6 +41,8 @@ type RoutesScreenProps = {
 };
 
 type RouteShape = "oneWay" | "loop";
+
+const warningOrange = "#E58B5B";
 
 const routeSections: Array<{
   key: RouteSectionKey;
@@ -211,6 +214,7 @@ const savedRouteRecapDefaults: Record<
 };
 
 export function RoutesScreen({
+  onAlertPress,
   onStartRoute,
 }: RoutesScreenProps) {
   const [searchValue, setSearchValue] = useState("");
@@ -218,36 +222,37 @@ export function RoutesScreen({
     routeSections[0].routes.map((route) => route.id),
   );
   const [activeQuickFilter, setActiveQuickFilter] = useState<string | null>(null);
-  const [routeNames, setRouteNames] = useState<Record<string, string>>({});
   const [routeReviews, setRouteReviews] = useState<Record<string, string>>({});
-  const [routeTags, setRouteTags] = useState<Record<string, string[]>>({});
+  const [routeReviewTags, setRouteReviewTags] = useState<Record<string, string[]>>({});
+  const [routeUserRatings, setRouteUserRatings] = useState<Record<string, number>>({});
   const [editingRouteId, setEditingRouteId] = useState<string | null>(null);
-  const [editingNameValue, setEditingNameValue] = useState("");
   const [editingReviewValue, setEditingReviewValue] = useState("");
+  const [editingRatingValue, setEditingRatingValue] = useState<number>(0);
   const [editingTagsValue, setEditingTagsValue] = useState<string[]>([]);
   const [isTagPickerOpen, setIsTagPickerOpen] = useState(false);
   const [editingRouteShapeValue, setEditingRouteShapeValue] =
     useState<RouteShape>("oneWay");
   const [editingSafetySettingsValue, setEditingSafetySettingsValue] = useState<string[]>([]);
   const [editingGroupJourneyValue, setEditingGroupJourneyValue] = useState(false);
-  const [isEditingName, setIsEditingName] = useState(false);
+  const [isReviewComposerOpen, setIsReviewComposerOpen] = useState(false);
+  const [pendingRemovalRouteId, setPendingRemovalRouteId] = useState<string | null>(null);
 
   const filteredSections = useMemo(() => {
     const query = searchValue.trim().toLowerCase();
     const quickFilter = activeQuickFilter?.toLowerCase() ?? "";
     const hasQuickFilter = quickFilter.length > 0;
 
-    if (!query && !hasQuickFilter) {
-      return routeSections;
-    }
-
     return routeSections
       .map((section) => ({
         ...section,
         routes: section.routes.filter((route) => {
-          const routeName = routeNames[route.id] ?? route.name;
+          if (section.key === "saved" && !savedRouteIds.includes(route.id)) {
+            return false;
+          }
+
+          const routeName = route.name;
           const routeReview = routeReviews[route.id] ?? route.snippet;
-          const tags = routeTags[route.id] ?? route.tags;
+          const tags = routeReviewTags[route.id] ?? route.tags;
           const searchableText = [
             routeName,
             routeReview,
@@ -267,7 +272,7 @@ export function RoutesScreen({
         }),
       }))
       .filter((section) => section.routes.length > 0);
-  }, [searchValue, activeQuickFilter, routeNames, routeReviews, routeTags]);
+  }, [searchValue, activeQuickFilter, routeReviews, routeReviewTags, savedRouteIds]);
 
   const savedSection = filteredSections.find((section) => section.key === "saved");
   const otherSections = filteredSections.filter((section) => section.key !== "saved");
@@ -277,6 +282,12 @@ export function RoutesScreen({
       : routeSections
           .flatMap((section) => section.routes)
           .find((route) => route.id === editingRouteId) ?? null;
+  const pendingRemovalRoute =
+    pendingRemovalRouteId === null
+      ? null
+      : routeSections
+          .flatMap((section) => section.routes)
+          .find((route) => route.id === pendingRemovalRouteId) ?? null;
 
   function toggleSavedRoute(routeId: string) {
     setSavedRouteIds((current) =>
@@ -288,7 +299,12 @@ export function RoutesScreen({
 
   function removeFromSaved(routeId: string) {
     setSavedRouteIds((current) => current.filter((id) => id !== routeId));
+    setPendingRemovalRouteId(null);
     cancelEditingRoute();
+  }
+
+  function requestRemoveFromSaved(routeId: string) {
+    setPendingRemovalRouteId(routeId);
   }
 
   function toggleQuickFilter(filter: string) {
@@ -298,68 +314,117 @@ export function RoutesScreen({
   function startEditingRoute(route: RouteItem) {
     const recapDefaults = savedRouteRecapDefaults[route.id];
     setEditingRouteId(route.id);
-    setEditingNameValue(routeNames[route.id] ?? route.name);
-    setEditingReviewValue(routeReviews[route.id] ?? route.snippet);
-    setEditingTagsValue(routeTags[route.id] ?? route.tags);
+    setEditingReviewValue(routeReviews[route.id] ?? "");
+    setEditingRatingValue(routeUserRatings[route.id] ?? 0);
+    setEditingTagsValue(routeReviewTags[route.id] ?? []);
     setEditingRouteShapeValue(recapDefaults?.routeShape ?? "oneWay");
     setEditingSafetySettingsValue(recapDefaults?.safetyFeatureIds ?? []);
     setEditingGroupJourneyValue(recapDefaults?.journeyMode === "Group");
-    setIsEditingName(false);
+    setIsReviewComposerOpen(false);
     setIsTagPickerOpen(false);
   }
 
   function cancelEditingRoute() {
     setEditingRouteId(null);
-    setEditingNameValue("");
     setEditingReviewValue("");
+    setEditingRatingValue(0);
     setEditingTagsValue([]);
     setEditingRouteShapeValue("oneWay");
     setEditingSafetySettingsValue([]);
     setEditingGroupJourneyValue(false);
-    setIsEditingName(false);
+    setIsReviewComposerOpen(false);
     setIsTagPickerOpen(false);
   }
 
-  function saveRouteName(route: RouteItem) {
-    const trimmedName = editingNameValue.trim();
-    const trimmedReview = editingReviewValue.trim();
+  function toggleEditingTag(tag: string) {
+    setEditingTagsValue((current) => {
+      if (current.includes(tag)) {
+        return current.filter((currentTag) => currentTag !== tag);
+      }
 
-    if (!trimmedName || !trimmedReview || editingTagsValue.length === 0) {
-      cancelEditingRoute();
-      return;
-    }
+      if (current.length >= 3) {
+        return current;
+      }
 
-    setRouteNames((current) => ({
-      ...current,
-      [route.id]: trimmedName,
-    }));
-    setRouteReviews((current) => ({
-      ...current,
-      [route.id]: trimmedReview,
-    }));
-    setRouteTags((current) => ({
-      ...current,
-      [route.id]: editingTagsValue,
-    }));
-    cancelEditingRoute();
+      return [...current, tag];
+    });
   }
 
-  function toggleEditingTag(tag: string) {
-    setEditingTagsValue((current) =>
-      current.includes(tag)
-        ? current.filter((currentTag) => currentTag !== tag)
-        : [...current, tag],
-    );
+  function openReviewComposer(route: RouteItem) {
+    setEditingReviewValue(routeReviews[route.id] ?? "");
+    setEditingRatingValue(routeUserRatings[route.id] ?? 0);
+    setEditingTagsValue(routeReviewTags[route.id] ?? []);
+    setIsTagPickerOpen(false);
+    setIsReviewComposerOpen(true);
+  }
+
+  function saveRouteReview(route: RouteItem) {
+    const trimmedReview = editingReviewValue.trim();
+
+    setRouteUserRatings((current) => {
+      if (editingRatingValue <= 0) {
+        const { [route.id]: _removed, ...rest } = current;
+        return rest;
+      }
+
+      return {
+        ...current,
+        [route.id]: editingRatingValue,
+      };
+    });
+    setRouteReviewTags((current) => {
+      if (editingTagsValue.length === 0) {
+        const { [route.id]: _removed, ...rest } = current;
+        return rest;
+      }
+
+      return {
+        ...current,
+        [route.id]: editingTagsValue,
+      };
+    });
+    setRouteReviews((current) => {
+      if (!trimmedReview) {
+        const { [route.id]: _removed, ...rest } = current;
+        return rest;
+      }
+
+      return {
+        ...current,
+        [route.id]: trimmedReview,
+      };
+    });
+    setIsTagPickerOpen(false);
+    setIsReviewComposerOpen(false);
+  }
+
+  function getReviewSummary(route: RouteItem) {
+    const rating = routeUserRatings[route.id];
+    const tags = routeReviewTags[route.id] ?? [];
+    const hasNote = Boolean(routeReviews[route.id]?.trim());
+    const parts: string[] = [];
+
+    if (rating) {
+      parts.push(`${rating} stars`);
+    }
+    if (tags.length > 0) {
+      parts.push(tags.length === 1 ? "1 tag" : `${tags.length} tags`);
+    }
+    if (hasNote) {
+      parts.push("note added");
+    }
+
+    return parts.length > 0 ? parts.join(" • ") : "No review yet";
   }
 
   function buildStartPreset(route: RouteItem): SavedRouteStartPreset {
     return {
       routeId: route.id,
-      routeName: routeNames[route.id] ?? route.name,
+      routeName: route.name,
       distance: route.distance,
       time: route.time,
       routeShape: savedRouteRecapDefaults[route.id]?.routeShape ?? "oneWay",
-      tags: routeTags[route.id] ?? route.tags,
+      tags: routeReviewTags[route.id] ?? route.tags,
       safetyFeatureIds: savedRouteRecapDefaults[route.id]?.safetyFeatureIds ?? [],
     };
   }
@@ -372,31 +437,15 @@ export function RoutesScreen({
             <Text style={styles.sectionTitle}>{section.title}</Text>
             <Text style={styles.sectionSubtitle}>{section.subtitle}</Text>
           </View>
-          <LinearGradient
-            colors={sectionAccent[section.key]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            style={styles.sectionBadge}
-          >
-            <Text style={styles.sectionBadgeText}>
-              {section.key === "reviewed"
-                ? "Top rated"
-                : section.key === "nearby"
-                  ? "Near you"
-                  : section.key === "saved"
-                    ? "Personal"
-                    : "Trending"}
-            </Text>
-          </LinearGradient>
         </View>
 
         <View style={styles.routeList}>
           {section.routes.map((route) => {
             const isSaved = savedRouteIds.includes(route.id);
             const canEditRoute = section.key === "saved";
-            const routeName = routeNames[route.id] ?? route.name;
+            const routeName = route.name;
             const routeReview = routeReviews[route.id] ?? route.snippet;
-            const tags = routeTags[route.id] ?? route.tags;
+            const tags = routeReviewTags[route.id] ?? route.tags;
 
             return (
               <View key={route.id} style={styles.routeCard}>
@@ -450,7 +499,7 @@ export function RoutesScreen({
                     style={styles.secondaryAction}
                   >
                     <Text style={styles.secondaryActionText}>
-                      {canEditRoute ? "Edit" : isSaved ? "Saved" : "Save"}
+                      {canEditRoute ? "View" : isSaved ? "Saved" : "Save"}
                     </Text>
                   </Pressable>
                   <Pressable
@@ -460,6 +509,14 @@ export function RoutesScreen({
                     <Text style={styles.primaryActionText}>Start Route</Text>
                   </Pressable>
                 </View>
+                {canEditRoute ? (
+                  <Pressable
+                    onPress={() => requestRemoveFromSaved(route.id)}
+                    style={styles.removeSavedButton}
+                  >
+                    <Text style={styles.removeSavedButtonText}>Unsave</Text>
+                  </Pressable>
+                ) : null}
               </View>
             );
           })}
@@ -480,12 +537,21 @@ export function RoutesScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
-        <View style={styles.pageIntro}>
-          <Text style={styles.pageEyebrow}>Explore</Text>
-          <Text style={styles.pageTitle}>Routes</Text>
-          <Text style={styles.pageSubtitle}>
-            Find a route that feels comfortable, safe, and right for your day.
-          </Text>
+        <View style={styles.pageIntroRow}>
+          <View style={styles.pageIntro}>
+            <Text style={styles.pageEyebrow}>Explore</Text>
+            <Text style={styles.pageTitle}>Routes</Text>
+            <Text style={styles.pageSubtitle}>
+              Find a route that feels comfortable, safe, and right for your day.
+            </Text>
+          </View>
+          <Pressable
+            onPress={onAlertPress}
+            style={({ pressed }) => [styles.alertButton, pressed && styles.alertPressed]}
+          >
+            <Feather name="bell" size={18} color={theme.colors.white} />
+            <View style={styles.alertDot} />
+          </Pressable>
         </View>
 
         <View style={styles.searchShell}>
@@ -549,7 +615,7 @@ export function RoutesScreen({
       </ScrollView>
 
       <Modal
-        visible={selectedRoute !== null}
+        visible={selectedRoute !== null && !isReviewComposerOpen}
         transparent
         animationType="fade"
         onRequestClose={cancelEditingRoute}
@@ -565,21 +631,8 @@ export function RoutesScreen({
               >
                 <View style={styles.modalHeader}>
                   <View style={styles.modalHeaderCopy}>
-                    <Text style={styles.modalReadyEyebrow}>Ready to start?</Text>
-                    {isEditingName ? (
-                      <TextInput
-                        value={editingNameValue}
-                        onChangeText={setEditingNameValue}
-                        placeholder="Route name"
-                        placeholderTextColor="rgba(79,90,34,0.52)"
-                        style={styles.modalReadyTitleInput}
-                        autoFocus
-                      />
-                    ) : (
-                      <Text style={styles.modalReadyTitle}>
-                        {routeNames[selectedRoute.id] ?? selectedRoute.name}
-                      </Text>
-                    )}
+                    <Text style={styles.modalReadyEyebrow}>Saved Route</Text>
+                    <Text style={styles.modalReadyTitle}>{selectedRoute.name}</Text>
                     <Text style={styles.modalReadyMeta}>
                       {selectedRoute.distance} • {selectedRoute.time} •{" "}
                       {editingRouteShapeValue === "loop" ? "Loop" : "One-way"}
@@ -607,29 +660,93 @@ export function RoutesScreen({
                     </View>
                   ))}
                 </View>
-              </LinearGradient>
-
-              <View style={styles.modalLocationCard}>
-                <View>
-                  <Text style={styles.modalLocationLabel}>Location</Text>
-                  <Text style={styles.modalLocationValue}>
+                <View style={styles.modalReadyLocationCard}>
+                  <Text style={styles.modalReadyLocationLabel}>Location</Text>
+                  <Text style={styles.modalReadyLocationValue}>
                     {savedRouteRecapDefaults[selectedRoute.id]?.startLocation ??
                       "Current location"}
                   </Text>
                 </View>
+              </LinearGradient>
+
+              <Pressable
+                onPress={() => openReviewComposer(selectedRoute)}
+                style={styles.reviewEntryCard}
+              >
+                <View style={styles.reviewEntryIconWrap}>
+                  <Feather name="message-square" size={18} color={theme.colors.brandDeep} />
+                </View>
+                <View style={styles.reviewEntryCopy}>
+                  <Text style={styles.reviewEntryLabel}>Your Review</Text>
+                  <Text style={styles.reviewEntryValue}>{getReviewSummary(selectedRoute)}</Text>
+                </View>
+                <View style={styles.reviewEntryActionPill}>
+                  <Text style={styles.reviewEntryAction}>
+                    {getReviewSummary(selectedRoute) === "No review yet" ? "Add" : "Edit"}
+                  </Text>
+                </View>
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+      </Modal>
+      <Modal
+        visible={selectedRoute !== null && isReviewComposerOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setIsReviewComposerOpen(false)}
+      >
+        {selectedRoute ? (
+          <View style={styles.reviewModalOverlay}>
+            <View style={styles.reviewModalCard}>
+              <View style={styles.reviewModalHeader}>
+                <View style={styles.reviewModalHeaderCopy}>
+                  <Text style={styles.reviewModalEyebrow}>Review This Route</Text>
+                  <Text style={styles.reviewModalTitle}>{selectedRoute.name}</Text>
+                </View>
+                <Pressable
+                  onPress={() => setIsReviewComposerOpen(false)}
+                  style={styles.modalCloseButton}
+                >
+                  <Text style={styles.modalCloseText}>×</Text>
+                </Pressable>
               </View>
 
-              <View style={styles.modalSection}>
-                <Text style={styles.modalSectionTitle}>Route Tags</Text>
-                <Text style={styles.modalHelperText}>
-                  Choose the tags that best describe this saved route.
-                </Text>
+              <Text style={styles.modalHelperText}>
+                Add a rating, choose up to 3 tags, and write a note if you want to.
+              </Text>
+
+              <View style={styles.reviewStarsRow}>
+                {[1, 2, 3, 4, 5].map((star) => {
+                  const selected = star <= editingRatingValue;
+
+                  return (
+                    <Pressable
+                      key={star}
+                      onPress={() => setEditingRatingValue(star)}
+                      style={styles.reviewStarButton}
+                    >
+                      <Feather
+                        name="star"
+                        size={20}
+                        color={selected ? theme.colors.brandDeep : "rgba(110,95,86,0.35)"}
+                      />
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <View style={styles.reviewTagBlock}>
+                <View style={styles.reviewTagHeader}>
+                  <Text style={styles.modalSectionTitle}>Tags</Text>
+                  <Text style={styles.reviewTagLimit}>Choose up to 3</Text>
+                </View>
                 <Pressable
                   onPress={() => setIsTagPickerOpen((current) => !current)}
                   style={styles.tagDropdownButton}
                 >
                   <Text style={styles.tagDropdownButtonText}>
-                    {isTagPickerOpen ? "Hide tag options" : "Choose route tags"}
+                    {isTagPickerOpen ? "Hide tag options" : "Choose review tags"}
                   </Text>
                   <Text style={styles.tagDropdownChevron}>
                     {isTagPickerOpen ? "⌃" : "⌄"}
@@ -643,6 +760,7 @@ export function RoutesScreen({
                   >
                     {availableRouteTags.map((tag) => {
                       const selected = editingTagsValue.includes(tag);
+                      const disabled = !selected && editingTagsValue.length >= 3;
 
                       return (
                         <Pressable
@@ -651,12 +769,14 @@ export function RoutesScreen({
                           style={[
                             styles.modalTagListItem,
                             selected && styles.modalTagListItemSelected,
+                            disabled && styles.modalTagListItemDisabled,
                           ]}
                         >
                           <Text
                             style={[
                               styles.modalTagListItemText,
                               selected && styles.modalTagListItemTextSelected,
+                              disabled && styles.modalTagListItemTextDisabled,
                             ]}
                           >
                             {tag}
@@ -665,16 +785,17 @@ export function RoutesScreen({
                             style={[
                               styles.modalTagListItemCheck,
                               selected && styles.modalTagListItemCheckSelected,
+                              disabled && styles.modalTagListItemCheckDisabled,
                             ]}
                           >
-                            {selected ? "Selected" : "Add"}
+                            {selected ? "Selected" : disabled ? "Max" : "Add"}
                           </Text>
                         </Pressable>
                       );
                     })}
                   </ScrollView>
                 ) : null}
-                {!isTagPickerOpen ? (
+                {editingTagsValue.length > 0 ? (
                   <View style={styles.tagRow}>
                     {editingTagsValue.map((tag) => (
                       <View key={tag} style={styles.tag}>
@@ -685,28 +806,71 @@ export function RoutesScreen({
                 ) : null}
               </View>
 
-              <View style={styles.modalActions}>
+              <TextInput
+                value={editingReviewValue}
+                onChangeText={setEditingReviewValue}
+                placeholder="Add your route review"
+                placeholderTextColor={theme.colors.textMuted}
+                multiline
+                textAlignVertical="top"
+                style={styles.reviewInput}
+                autoFocus
+              />
+
+              <View style={styles.reviewModalActions}>
                 <Pressable
-                  onPress={() => setIsEditingName((current) => !current)}
+                  onPress={() => setIsReviewComposerOpen(false)}
                   style={styles.secondaryAction}
                 >
-                  <Text style={styles.secondaryActionText}>
-                    {isEditingName ? "Done" : "Edit"}
-                  </Text>
+                  <Text style={styles.secondaryActionText}>Cancel</Text>
                 </Pressable>
                 <Pressable
-                  onPress={() => saveRouteName(selectedRoute)}
+                  onPress={() => saveRouteReview(selectedRoute)}
                   style={styles.primaryAction}
                 >
-                  <Text style={styles.primaryActionText}>Save Changes</Text>
+                  <Text style={styles.primaryActionText}>Save Review</Text>
                 </Pressable>
               </View>
-              <Pressable
-                onPress={() => removeFromSaved(selectedRoute.id)}
-                style={styles.removeSavedButton}
-              >
-                <Text style={styles.removeSavedButtonText}>Remove from Saved</Text>
-              </Pressable>
+            </View>
+          </View>
+        ) : null}
+      </Modal>
+      <Modal
+        visible={pendingRemovalRoute !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setPendingRemovalRouteId(null)}
+      >
+        {pendingRemovalRoute ? (
+          <View style={styles.removeConfirmOverlay}>
+            <View style={styles.removeConfirmCard}>
+              <View style={styles.reviewModalHeader}>
+                <View style={styles.reviewModalHeaderCopy}>
+                  <Text style={styles.removeConfirmEyebrow}>Remove Saved Route</Text>
+                  <Text style={styles.removeConfirmTitle}>
+                    Remove {pendingRemovalRoute.name}?
+                  </Text>
+                </View>
+                <Pressable
+                  onPress={() => setPendingRemovalRouteId(null)}
+                  style={styles.modalCloseButton}
+                >
+                  <Text style={styles.modalCloseText}>×</Text>
+                </Pressable>
+              </View>
+
+              <Text style={styles.removeConfirmText}>
+                This route will be removed from your saved routes. You can always save it again later if you want it back.
+              </Text>
+
+              <View style={styles.reviewModalActions}>
+                <Pressable
+                  onPress={() => removeFromSaved(pendingRemovalRoute.id)}
+                  style={styles.removeSavedButtonConfirm}
+                >
+                  <Text style={styles.removeSavedButtonConfirmText}>Remove Route</Text>
+                </Pressable>
+              </View>
             </View>
           </View>
         ) : null}
@@ -728,6 +892,13 @@ const styles = StyleSheet.create({
   },
   pageIntro: {
     gap: 6,
+    flex: 1,
+  },
+  pageIntroRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 14,
   },
   pageEyebrow: {
     fontSize: 11,
@@ -747,6 +918,34 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     color: theme.colors.textSoft,
     maxWidth: 320,
+  },
+  alertButton: {
+    minWidth: 60,
+    minHeight: 46,
+    paddingHorizontal: 8,
+    paddingVertical: 11,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.brandBright,
+    position: "relative",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.18,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+  },
+  alertPressed: {
+    opacity: 0.9,
+  },
+  alertDot: {
+    position: "absolute",
+    top: 8,
+    right: 8,
+    width: 8,
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: "#FF6A5B",
   },
   searchShell: {
     flexDirection: "row",
@@ -832,16 +1031,6 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontSize: 14,
     color: theme.colors.textSoft,
-  },
-  sectionBadge: {
-    borderRadius: theme.radius.pill,
-    paddingHorizontal: 13,
-    paddingVertical: 10,
-  },
-  sectionBadgeText: {
-    fontSize: 12,
-    fontWeight: "800",
-    color: theme.colors.white,
   },
   routeList: {
     gap: 12,
@@ -972,19 +1161,42 @@ const styles = StyleSheet.create({
     color: theme.colors.white,
   },
   removeSavedButton: {
-    marginTop: 12,
+    marginTop: 4,
     borderRadius: 18,
-    backgroundColor: theme.colors.ink,
+    backgroundColor: theme.colors.white,
     borderWidth: 1,
-    borderColor: theme.colors.ink,
+    borderColor: theme.colors.border,
     alignItems: "center",
     justifyContent: "center",
-    paddingVertical: 13,
+    alignSelf: "stretch",
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    shadowColor: "rgba(95,53,37,0.18)",
+    shadowOpacity: 0.12,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
   },
   removeSavedButtonText: {
     fontSize: 14,
     fontWeight: "800",
-    color: theme.colors.white,
+    color: theme.colors.brandDeep,
+  },
+  removeSavedButtonConfirm: {
+    borderRadius: 20,
+    backgroundColor: "#FFF8F2",
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "center",
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.72)",
+  },
+  removeSavedButtonConfirmText: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: "#000000",
   },
   modalOverlay: {
     flex: 1,
@@ -1057,19 +1269,25 @@ const styles = StyleSheet.create({
     color: "#4F5A22",
   },
   modalCloseButton: {
-    width: 34,
-    height: 34,
-    borderRadius: 17,
+    width: 42,
+    height: 42,
+    borderRadius: 21,
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "rgba(79,90,34,0.1)",
+    backgroundColor: "rgba(255,255,255,0.82)",
     borderWidth: 1,
-    borderColor: "rgba(79,90,34,0.12)",
+    borderColor: "rgba(79,90,34,0.22)",
+    shadowColor: "rgba(79,90,34,0.34)",
+    shadowOpacity: 0.16,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 3,
   },
   modalCloseText: {
-    fontSize: 20,
-    lineHeight: 22,
-    color: "#566126",
+    fontSize: 22,
+    lineHeight: 24,
+    fontWeight: "900",
+    color: "#394115",
   },
   modalReadySummaryRow: {
     flexDirection: "row",
@@ -1105,34 +1323,205 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: theme.colors.text,
   },
-  modalLocationCard: {
+  modalReadyLocationCard: {
     borderRadius: 22,
-    backgroundColor: theme.colors.surfaceOrangeDeep,
+    backgroundColor: "rgba(255,249,244,0.3)",
     paddingHorizontal: 14,
     paddingVertical: 11,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    gap: 12,
     borderWidth: 1,
-    borderColor: "rgba(202,116,73,0.3)",
+    borderColor: "rgba(79,90,34,0.14)",
+    marginTop: 4,
   },
-  modalLocationLabel: {
+  modalReadyLocationLabel: {
     fontSize: 13,
-    color: "rgba(111,72,46,0.86)",
+    color: "rgba(86,97,38,0.82)",
     fontWeight: "700",
   },
-  modalLocationValue: {
+  modalReadyLocationValue: {
     marginTop: 3,
-    fontSize: 20,
-    lineHeight: 24,
-    fontWeight: "900",
-    color: theme.colors.text,
+    fontSize: 18,
+    lineHeight: 22,
+    fontWeight: "800",
+    color: "#4F5A22",
   },
   modalReviewRating: {
     fontSize: 15,
     fontWeight: "800",
     color: theme.colors.brandDeep,
+  },
+  reviewEntryCard: {
+    borderRadius: 22,
+    backgroundColor: theme.colors.surfaceOrange,
+    paddingHorizontal: 14,
+    paddingVertical: 15,
+    borderWidth: 1,
+    borderColor: "rgba(202,116,73,0.18)",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.08,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 3,
+  },
+  reviewEntryIconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: 14,
+    backgroundColor: theme.colors.surfaceOrangeDeep,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  reviewEntryCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  reviewEntryLabel: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: "#7D543B",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  reviewEntryValue: {
+    fontSize: 15,
+    lineHeight: 21,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  reviewEntryActionPill: {
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(255,249,244,0.96)",
+    borderWidth: 1,
+    borderColor: "rgba(202,116,73,0.18)",
+    paddingHorizontal: 13,
+    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  reviewEntryAction: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  removeConfirmOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(95,53,37,0.42)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  removeConfirmCard: {
+    width: "100%",
+    borderRadius: 28,
+    backgroundColor: warningOrange,
+    padding: 22,
+    gap: 16,
+    borderWidth: 1,
+    borderColor: warningOrange,
+    shadowColor: warningOrange,
+    shadowOpacity: 0.18,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 8,
+  },
+  removeConfirmEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: "rgba(255,245,240,0.82)",
+  },
+  removeConfirmTitle: {
+    fontSize: 22,
+    lineHeight: 26,
+    fontWeight: "900",
+    color: theme.colors.white,
+  },
+  removeConfirmText: {
+    fontSize: 15,
+    lineHeight: 22,
+    fontWeight: "700",
+    color: theme.colors.white,
+  },
+  reviewModalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(62,44,35,0.34)",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  reviewModalCard: {
+    width: "100%",
+    borderRadius: 28,
+    backgroundColor: "#FFF8F2",
+    padding: 20,
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "rgba(223,202,188,0.9)",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.14,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 10 },
+    elevation: 8,
+  },
+  reviewModalHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  reviewModalHeaderCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  reviewModalEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
+  },
+  reviewModalTitle: {
+    fontSize: 22,
+    lineHeight: 26,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  reviewStarsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  reviewStarButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 14,
+    backgroundColor: "rgba(255,255,255,0.76)",
+    borderWidth: 1,
+    borderColor: "rgba(216,192,176,0.72)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  reviewTagBlock: {
+    gap: 10,
+  },
+  reviewTagHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  reviewTagLimit: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+  },
+  reviewModalActions: {
+    alignItems: "center",
+    marginTop: 2,
   },
   reviewInput: {
     minHeight: 96,
@@ -1191,16 +1580,25 @@ const styles = StyleSheet.create({
   modalTagListItemSelected: {
     backgroundColor: "#AFCB46",
   },
+  modalTagListItemDisabled: {
+    backgroundColor: "rgba(255,255,255,0.82)",
+  },
   modalTagListItemText: {
     fontSize: 15,
     fontWeight: "700",
     color: theme.colors.text,
+  },
+  modalTagListItemTextDisabled: {
+    color: "rgba(98,85,86,0.48)",
   },
   modalTagListItemCheck: {
     fontSize: 11,
     fontWeight: "800",
     color: theme.colors.textSoft,
     textTransform: "uppercase",
+  },
+  modalTagListItemCheckDisabled: {
+    color: "rgba(98,85,86,0.48)",
   },
   modalTagListItemCheckSelected: {
     color: "#2F3615",

--- a/apps/mobile/src/screens/StartJourneyScreen.tsx
+++ b/apps/mobile/src/screens/StartJourneyScreen.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Modal,
   Pressable,
@@ -11,10 +11,12 @@ import {
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { theme } from "../styles/theme";
+import type { SavedRouteStartPreset } from "./RoutesScreen";
 
 type StartJourneyScreenProps = {
   onStartJourney?: (journeyConfig: StartJourneyConfig) => void;
   onOpenProfile?: () => void;
+  initialRoutePreset?: SavedRouteStartPreset | null;
 };
 
 export type JourneyType = "walk" | "run" | "hike" | "bike";
@@ -46,6 +48,13 @@ export type StartJourneyConfig = {
   contactLabel: string;
   startedAt: string;
 };
+
+const defaultIncludedSafetyIds = [
+  "off-route",
+  "missed-check-in",
+  "emergency",
+  "check-ins",
+] as const;
 
 const readyLimeLight = "#CFE17A";
 const readyLime = "#AFCB46";
@@ -133,6 +142,7 @@ const journeySpeedMph: Record<JourneyType, number> = {
 export function StartJourneyScreen({
   onStartJourney,
   onOpenProfile,
+  initialRoutePreset = null,
 }: StartJourneyScreenProps) {
   const safetyScrollRef = useRef<ScrollView | null>(null);
   const [journeyType, setJourneyType] = useState<JourneyType>("walk");
@@ -150,7 +160,7 @@ export function StartJourneyScreen({
   const [groupMemberList, setGroupMemberList] =
     useState<EditableContact[]>(initialGroupMembers);
   const [includedSafetyIds, setIncludedSafetyIds] =
-    useState<string[]>(["off-route", "missed-check-in", "emergency", "check-ins"]);
+    useState<string[]>([...defaultIncludedSafetyIds]);
   const [selectedTrustedContactName, setSelectedTrustedContactName] =
     useState(
       initialTrustedContacts[0]
@@ -226,7 +236,40 @@ export function StartJourneyScreen({
   const journeyLabel =
     locationMode === "custom" && destinationLocation.trim().length > 0
       ? destinationLocation.trim()
+      : initialRoutePreset?.routeName?.trim()
+        ? initialRoutePreset.routeName
       : `${selectedJourney?.label ?? "Journey"} ${routeShape === "loop" ? "Loop" : "Route"}`;
+
+  useEffect(() => {
+    if (!initialRoutePreset) {
+      return;
+    }
+
+    const distanceMatch = initialRoutePreset.distance.match(/^([\d.]+)\s*(mi|km)$/i);
+    if (distanceMatch) {
+      setMeasureType("distance");
+      setDistanceValue(distanceMatch[1]);
+      setDistanceUnit(distanceMatch[2].toLowerCase());
+    }
+
+    const timeMatch = initialRoutePreset.time.match(
+      /^(?:(\d+)\s*hr\s*)?(?:(\d+)\s*min)$/i,
+    );
+    if (timeMatch) {
+      const parsedHours = timeMatch[1] ?? "0";
+      const parsedMinutes = timeMatch[2] ?? "0";
+      setDurationHours(parsedHours);
+      setDurationMinutes(parsedMinutes);
+    }
+
+    setRouteShape(initialRoutePreset.routeShape);
+    setIncludedSafetyIds(
+      Array.isArray(initialRoutePreset.safetyFeatureIds) &&
+        initialRoutePreset.safetyFeatureIds.length > 0
+        ? initialRoutePreset.safetyFeatureIds
+        : [...defaultIncludedSafetyIds],
+    );
+  }, [initialRoutePreset]);
 
   function openContactEditor(contact: EditableContact, isGroupContact: boolean) {
     setEditingContact({ ...contact });
@@ -427,6 +470,19 @@ export function StartJourneyScreen({
         contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
+        {initialRoutePreset ? (
+          <View style={styles.savedRoutePresetCard}>
+            <Text style={styles.savedRoutePresetEyebrow}>Saved Route</Text>
+            <Text style={styles.savedRoutePresetTitle}>
+              {initialRoutePreset.routeName}
+            </Text>
+            <Text style={styles.savedRoutePresetText}>
+              {initialRoutePreset.distance} • {initialRoutePreset.time} •{" "}
+              {initialRoutePreset.routeShape === "loop" ? "Loop" : "One-way"}
+            </Text>
+          </View>
+        ) : null}
+
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionEyebrow}>Journey type</Text>
@@ -1122,6 +1178,37 @@ const styles = StyleSheet.create({
     paddingTop: 18,
     paddingBottom: 180,
     gap: 18,
+  },
+  savedRoutePresetCard: {
+    borderRadius: 24,
+    backgroundColor: "rgba(255,255,255,0.98)",
+    padding: 18,
+    borderWidth: 1,
+    borderColor: "rgba(223,202,188,0.9)",
+    shadowColor: theme.colors.brandDeep,
+    shadowOpacity: 0.08,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 4,
+    gap: 6,
+  },
+  savedRoutePresetEyebrow: {
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 1.2,
+    textTransform: "uppercase",
+    color: theme.colors.textMuted,
+  },
+  savedRoutePresetTitle: {
+    fontSize: 24,
+    lineHeight: 28,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  savedRoutePresetText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
   },
   progressBanner: {
     borderRadius: 30,


### PR DESCRIPTION
### Summary
This PR significantly refines the mobile Routes experience by improving discoverability, saved/favorite route management, and journey handoff. It also tightens navigation behavior so route choices flow into Start Journey with prefilled data.

### What changed
- Reworked the Routes screen into sectioned route groups (Saved, Popular, Reviewed, Nearby) with search and quick filters for faster discovery.
- Added richer saved-route interactions:
-         save/unsave with feedback toast,
-         removal confirmation modal,
-         favorite toggle logic that syncs with Home favorites.
- Added route detail and review flows:
-         saved-route recap modal,
-         review composer with star rating + up to 3 tags + optional note.
- Added route-to-journey preset plumbing:
-         Routes now emits SavedRouteStartPreset,
-         AppNavigator passes pending route presets to Start Journey,
-         Start Journey preloads distance/time/shape/safety defaults from selected route.
- Updated Home to consume favorite route summary so Favorites reflects user route selections.
- Improved bottom nav center-button behavior so certain screens show a Home target, with a routes-specific visual treatment.
- Replaced Alerts content with an unavailable placeholder and “View Journey” action fallback.

### Why
These updates make route selection more actionable and cohesive:
-     users can find routes quickly,
-     manage saved/favorite intent with less friction,
-     carry route context into journey setup without re-entry.

### Testing notes (suggested for PR body)
-     Manually verify:
     1. Search + quick filters correctly narrow route cards.
     2. Save/unsave and favorite state updates are reflected on Home.
     3. Start Route from Routes prepopulates Start Journey fields.
     4. Alerts “View Journey” routes to active journey when present, otherwise Home.
     5. Nav center button behavior across Home/Routes/Start/Active Journey screens.

### Risks / follow-ups
-      State is local to in-memory UI and not persisted yet (favorites/saved/reviews reset on restart).
-     Large RoutesScreen.tsx may be a good candidate for component extraction in a follow-up.