### PR TITLE
feat: polish mobile navigation and redesign core account screens

### DIFF
--- a/apps/mobile/src/components/NavBar.tsx
+++ b/apps/mobile/src/components/NavBar.tsx
@@ -50,7 +50,7 @@ export function NavBar({
       : "Start";
 
   const centerBottomLabel = showsHomeCenterButton ? "" : "Journey";
-  const centerButtonColors = showsHomeCenterButton
+  const centerButtonColors: [string, string] = showsHomeCenterButton
     ? usesGreenHomeButton
       ? [centerGreen, centerGreen]
       : [navPeach, navPeach]

--- a/apps/mobile/src/components/NavBar.tsx
+++ b/apps/mobile/src/components/NavBar.tsx
@@ -28,12 +28,13 @@ export function NavBar({
   hasActiveJourney = false,
   onNavigate,
 }: NavBarProps) {
-  const isJourneyScreen = activeScreen === "startJourney";
-  const isActiveJourneyScreen = activeScreen === "activeJourney";
-  const isRoutesScreen = activeScreen === "routes";
-  const showsHomeCenterButton =
-    isJourneyScreen || isActiveJourneyScreen || isRoutesScreen;
-  const usesGreenHomeButton = isRoutesScreen;
+  const showsHomeCenterButton = activeScreen !== "home";
+  const usesGreenHomeButton =
+    activeScreen === "routes" ||
+    activeScreen === "stats" ||
+    activeScreen === "profile" ||
+    activeScreen === "settings" ||
+    activeScreen === "activeJourney";
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   const centerTarget =

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -8,13 +8,9 @@ import {
   type JourneyAlert,
 } from "../alerts/alertData";
 import { AlertToast } from "../components/AlertToast";
-
-// 1. Import all of the screens!
 import { NavBar } from "../components/NavBar";
 import { HomeScreen } from "../screens/HomeScreen";
-// Note: Based on your previous code, these were created as "default" exports, 
-// so they don't use the curly braces { } around the name.
-import ProfileScreen from "../screens/ProfileScreen"; 
+import ProfileScreen from "../screens/ProfileScreen";
 import SettingsScreen from "../screens/SettingsScreen";
 import StatisticsScreen from "../screens/StatisticsScreen";
 import {
@@ -29,12 +25,91 @@ import {
   StartJourneyScreen,
   type StartJourneyConfig,
 } from "../screens/StartJourneyScreen";
+import { theme, AppScreen } from "../styles/theme";
+import type {
+  StatsSnapshot,
+  TrustedContact,
+  UserProfile,
+  UserSettings,
+} from "../types/appData";
 
-// Import the team's theme and the AppScreen type
-import { theme, AppScreen } from "../styles/theme"; 
+const initialTrustedContacts: TrustedContact[] = [
+  {
+    id: "maya",
+    firstName: "Maya",
+    lastName: "Lopez",
+    phone: "(918) 555-0143",
+    note: "Mom",
+  },
+  {
+    id: "jordan",
+    firstName: "Jordan",
+    lastName: "Reed",
+    phone: "(918) 555-0188",
+    note: "Best friend",
+  },
+  {
+    id: "chris",
+    firstName: "Chris",
+    lastName: "Parker",
+    phone: "(918) 555-0121",
+    note: "Emergency contact",
+  },
+];
+
+const initialProfile: UserProfile = {
+  firstName: "Melissa",
+  lastName: "West",
+  headline: "Student builder and trail regular",
+  bio: "Balancing engineering projects with long walks, route reviews, and safer solo outings.",
+  city: "Tulsa, OK",
+  privacyLabel: "Visible to trusted contacts during active journeys",
+  memberSince: "January 2026",
+  nextMilestone: "200 trail miles",
+};
+
+const initialSettings: UserSettings = {
+  autoShareLocation: true,
+  pushNotifications: true,
+  routeDeviationAlerts: true,
+  missedCheckInAlerts: true,
+  weeklyDigest: true,
+  locationVisibility: "during journey",
+  defaultJourneyMode: "solo",
+};
+
+const initialStats: StatsSnapshot = {
+  milesThisWeek: 15.4,
+  weeklyGoalMiles: 20,
+  safeJourneys: 48,
+  hoursOutside: 142,
+  currentStreakDays: 5,
+  completionRate: 96,
+  checkInRate: 92,
+  favoriteRouteTitle: defaultFavoriteRoute.title,
+  lastJourneyLabel: "River Parks Morning Walk",
+  nextGoalLabel: "Hit 20 miles this week",
+};
+
+function getJourneyMiles(journeyConfig: StartJourneyConfig | null) {
+  if (!journeyConfig) {
+    return 0;
+  }
+
+  const milesMatch = journeyConfig.tripSetupLabel.match(/([\d.]+)\s*mi/i);
+  if (milesMatch) {
+    return Number(milesMatch[1]) || 0;
+  }
+
+  const kilometersMatch = journeyConfig.tripSetupLabel.match(/([\d.]+)\s*km/i);
+  if (kilometersMatch) {
+    return (Number(kilometersMatch[1]) || 0) * 0.621371;
+  }
+
+  return Math.max(1, journeyConfig.plannedDurationMinutes / 30);
+}
 
 export function AppNavigator() {
-  // 2. Create the State to track the active screen (defaults to "home")
   const [currentScreen, setCurrentScreen] = useState<AppScreen>("home");
   const [isAlertsOpen, setIsAlertsOpen] = useState(false);
   const [activeJourneyConfig, setActiveJourneyConfig] =
@@ -47,6 +122,12 @@ export function AppNavigator() {
   const [toastAlertId, setToastAlertId] = useState<string | null>(
     initialAlerts[0]?.id ?? null,
   );
+  const [trustedContacts, setTrustedContacts] =
+    useState<TrustedContact[]>(initialTrustedContacts);
+  const [profile] = useState<UserProfile>(initialProfile);
+  const [settings, setSettings] = useState<UserSettings>(initialSettings);
+  const [statsSnapshot, setStatsSnapshot] = useState<StatsSnapshot>(initialStats);
+
   const openAlerts = () => setIsAlertsOpen(true);
   const activeToast = useMemo(
     () => alerts.find((alert) => alert.id === toastAlertId) ?? null,
@@ -57,6 +138,26 @@ export function AppNavigator() {
       alert.type === "missed-check-in" ||
       alert.type === "off-route" ||
       alert.type === "escalation",
+  );
+  const urgentAlertsCount = alerts.filter(
+    (alert) =>
+      alert.type === "missed-check-in" ||
+      alert.type === "off-route" ||
+      alert.type === "escalation",
+  ).length;
+  const primaryContact =
+    trustedContacts[0]
+      ? `${trustedContacts[0].firstName} ${trustedContacts[0].lastName}`.trim()
+      : "No trusted contact selected";
+
+  const liveStats = useMemo<StatsSnapshot>(
+    () => ({
+      ...statsSnapshot,
+      favoriteRouteTitle: favoriteRoute?.title ?? statsSnapshot.favoriteRouteTitle,
+      lastJourneyLabel:
+        activeJourneyConfig?.journeyLabel ?? statsSnapshot.lastJourneyLabel,
+    }),
+    [activeJourneyConfig, favoriteRoute, statsSnapshot],
   );
 
   useEffect(() => {
@@ -109,18 +210,30 @@ export function AppNavigator() {
       return;
     }
 
-    if (action.label === "Close") {
+    if (action.label === "Close" || action.label === "Dismiss") {
       dismissAlert(alertId);
-      return;
-    }
-
-    if (action.label === "Dismiss") {
-      dismissAlert(alertId);
-      return;
     }
   }
 
-  // 3. Create a router function to swap the UI based on the state
+  function handleJourneyComplete() {
+    if (activeJourneyConfig) {
+      const completedMiles = getJourneyMiles(activeJourneyConfig);
+      setStatsSnapshot((current) => ({
+        ...current,
+        milesThisWeek: Number((current.milesThisWeek + completedMiles).toFixed(1)),
+        safeJourneys: current.safeJourneys + 1,
+        hoursOutside: Number(
+          (current.hoursOutside + activeJourneyConfig.plannedDurationMinutes / 60).toFixed(1),
+        ),
+        currentStreakDays: current.currentStreakDays + 1,
+        lastJourneyLabel: activeJourneyConfig.journeyLabel,
+      }));
+    }
+
+    setActiveJourneyConfig(null);
+    setCurrentScreen("home");
+  }
+
   const renderScreen = () => {
     switch (currentScreen) {
       case "home":
@@ -154,21 +267,92 @@ export function AppNavigator() {
       case "profile":
         return (
           <ProfileScreen
+            profile={profile}
+            stats={liveStats}
+            trustedContacts={trustedContacts}
+            settings={settings}
+            primaryContactName={primaryContact}
             onOpenAlerts={openAlerts}
+            onOpenStats={() => setCurrentScreen("stats")}
+            onOpenSettings={() => setCurrentScreen("settings")}
+            onOpenRoutes={() => setCurrentScreen("routes")}
+            onOpenStartJourney={() => {
+              setPendingRoutePreset(null);
+              setCurrentScreen("startJourney");
+            }}
             hasAlertIndicator={hasAlertIndicator}
           />
         );
       case "settings":
         return (
           <SettingsScreen
+            settings={settings}
+            trustedContacts={trustedContacts}
+            urgentAlertsCount={urgentAlertsCount}
             onOpenAlerts={openAlerts}
+            onOpenProfile={() => setCurrentScreen("profile")}
+            onOpenStats={() => setCurrentScreen("stats")}
+            onOpenRoutes={() => setCurrentScreen("routes")}
+            onOpenStartJourney={() => {
+              setPendingRoutePreset(null);
+              setCurrentScreen("startJourney");
+            }}
+            onToggleSetting={(key) =>
+              setSettings((current) => ({
+                ...current,
+                [key]: !current[key],
+              }))
+            }
+            onCycleLocationVisibility={() =>
+              setSettings((current) => ({
+                ...current,
+                locationVisibility:
+                  current.locationVisibility === "private"
+                    ? "trusted contacts"
+                    : current.locationVisibility === "trusted contacts"
+                      ? "during journey"
+                      : "private",
+              }))
+            }
+            onCycleDefaultJourneyMode={() =>
+              setSettings((current) => ({
+                ...current,
+                defaultJourneyMode:
+                  current.defaultJourneyMode === "solo" ? "group" : "solo",
+              }))
+            }
+            onPromoteContact={(contactId) =>
+              setTrustedContacts((current) => {
+                const selectedContact = current.find((contact) => contact.id === contactId);
+                if (!selectedContact) {
+                  return current;
+                }
+
+                return [
+                  selectedContact,
+                  ...current.filter((contact) => contact.id !== contactId),
+                ];
+              })
+            }
             hasAlertIndicator={hasAlertIndicator}
           />
         );
       case "stats":
         return (
           <StatisticsScreen
+            stats={liveStats}
+            trustedContacts={trustedContacts}
+            settings={settings}
+            hasActiveJourney={Boolean(activeJourneyConfig)}
+            urgentAlertsCount={urgentAlertsCount}
             onOpenAlerts={openAlerts}
+            onOpenRoutes={() => setCurrentScreen("routes")}
+            onOpenStartJourney={() => {
+              setPendingRoutePreset(null);
+              setCurrentScreen("startJourney");
+            }}
+            onOpenProfile={() => setCurrentScreen("profile")}
+            onOpenSettings={() => setCurrentScreen("settings")}
             hasAlertIndicator={hasAlertIndicator}
           />
         );
@@ -176,6 +360,8 @@ export function AppNavigator() {
         return (
           <StartJourneyScreen
             initialRoutePreset={pendingRoutePreset}
+            trustedContacts={trustedContacts}
+            defaultJourneyMode={settings.defaultJourneyMode}
             onStartJourney={(journeyConfig) => {
               setActiveJourneyConfig(journeyConfig);
               setPendingRoutePreset(null);
@@ -191,15 +377,10 @@ export function AppNavigator() {
           <ActiveJourneyScreen
             journeyConfig={activeJourneyConfig}
             onOpenAlerts={openAlerts}
-            onJourneyComplete={() => {
-              setActiveJourneyConfig(null);
-              setCurrentScreen("home");
-            }}
+            onJourneyComplete={handleJourneyComplete}
             hasAlertIndicator={hasAlertIndicator}
           />
         );
-      // If "routes" or "startJourney" is clicked before they are built, 
-      // safely fallback to home so the app doesn't crash!
       default:
         return (
           <HomeScreen
@@ -214,7 +395,7 @@ export function AppNavigator() {
             journeyMode={activeJourneyConfig ? "active" : "idle"}
             hasAlertIndicator={hasAlertIndicator}
           />
-        ); 
+        );
     }
   };
 
@@ -229,8 +410,7 @@ export function AppNavigator() {
             onOpenAlerts={openAlerts}
           />
         ) : null}
-        
-        {/* 4. Render the dynamic screen instead of the hardcoded HomeScreen */}
+
         {renderScreen()}
 
         <Modal
@@ -247,19 +427,16 @@ export function AppNavigator() {
           />
         </Modal>
 
-        {/* 5. Pass the state into the NavBar so it knows which button to highlight, 
-            and what to do when a new button is pressed */}
-        <NavBar 
-          activeScreen={currentScreen} 
+        <NavBar
+          activeScreen={currentScreen}
           hasActiveJourney={Boolean(activeJourneyConfig)}
           onNavigate={(screen) => {
             if (screen === "startJourney") {
               setPendingRoutePreset(null);
             }
             setCurrentScreen(screen);
-          }} 
+          }}
         />
-        
       </View>
     </SafeAreaView>
   );
@@ -268,13 +445,10 @@ export function AppNavigator() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    // The team set a global background color here
-    backgroundColor: theme.colors.background, 
+    backgroundColor: theme.colors.background,
   },
   container: {
     flex: 1,
-    // Note: We leave a little padding at the bottom so the screens 
-    // don't hide behind the floating navigation bar!
-    paddingBottom: 90, 
+    paddingBottom: 90,
   },
 });

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -150,7 +150,7 @@ export function HomeScreen({
           <View style={styles.mapTopRow}>
             <View style={styles.mapBrand}>
               <View style={styles.mapBrandLogoWrap}>
-                <AnimatedWayPointLogo size={92} />
+                <AnimatedWayPointLogo size={84} />
               </View>
               <View style={styles.mapBrandCopy}>
                 <Text style={styles.mapBrandTitle}>
@@ -387,6 +387,8 @@ const styles = StyleSheet.create({
     alignItems: "flex-start",
     justifyContent: "space-between",
     gap: 12,
+    zIndex: 3,
+    elevation: 3,
   },
   mapBrand: {
     flexDirection: "row",
@@ -404,11 +406,16 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     elevation: 2,
     minWidth: 0,
+    zIndex: 4,
   },
   mapBrandLogoWrap: {
-    marginTop: -22,
-    marginBottom: -22,
+    marginTop: -24,
+    marginBottom: -24,
     marginLeft: -8,
+    width: 92,
+    height: 92,
+    alignItems: "center",
+    justifyContent: "center",
   },
   mapBrandCopy: {
     marginLeft: -10,

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -1,314 +1,521 @@
-import React from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Feather } from '@expo/vector-icons'; // Expo's built-in icon library!
-
-// Your new experimental palette!
-const pageColors = {
-  lightGreen: '#B2EF91',
-  tangerine: '#FA9372',
-  charcoal: '#2C3E50',
-  papaya: '#FDEBD0',
-  coolSteel: '#77A0A9',
-  white: '#FFFFFF',
-};
+import React from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import { theme } from "../styles/theme";
+import type {
+  StatsSnapshot,
+  TrustedContact,
+  UserProfile,
+  UserSettings,
+} from "../types/appData";
 
 type ProfileScreenProps = {
+  profile: UserProfile;
+  stats: StatsSnapshot;
+  trustedContacts: TrustedContact[];
+  settings: UserSettings;
+  primaryContactName: string;
   onOpenAlerts?: () => void;
+  onOpenStats?: () => void;
+  onOpenSettings?: () => void;
+  onOpenRoutes?: () => void;
+  onOpenStartJourney?: () => void;
   hasAlertIndicator?: boolean;
 };
 
+function getInitials(profile: UserProfile) {
+  return `${profile.firstName[0] ?? ""}${profile.lastName[0] ?? ""}`.toUpperCase();
+}
+
 export default function ProfileScreen({
+  profile,
+  stats,
+  trustedContacts,
+  settings,
+  primaryContactName,
   onOpenAlerts,
+  onOpenStats,
+  onOpenSettings,
+  onOpenRoutes,
+  onOpenStartJourney,
   hasAlertIndicator = false,
 }: ProfileScreenProps) {
+  const weeklyProgress = Math.min(100, Math.round((stats.milesThisWeek / stats.weeklyGoalMiles) * 100));
+
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.scrollContent}>
-      <View style={styles.pageTopRow}>
-        <View style={styles.pageTopSpacer} />
-        <TouchableOpacity style={styles.alertButton} onPress={onOpenAlerts}>
-          <Feather name="bell" size={18} color={pageColors.white} />
-          {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
-        </TouchableOpacity>
-      </View>
-      
-      {/* --- HEADER WIDGET (Now with Edit features!) --- */}
-      <View style={[styles.bubbleCard, styles.headerCard]}>
-        
-        {/* Edit Profile Button (Top Right) */}
-        <TouchableOpacity style={styles.editButton}>
-          <Feather name="edit-2" size={20} color={pageColors.charcoal} />
-        </TouchableOpacity>
-
-        {/* Avatar with Camera Overlay */}
-        <TouchableOpacity style={styles.avatarContainer}>
-          <View style={styles.avatarPlaceholder} />
-          <View style={styles.cameraBadge}>
-            <Feather name="camera" size={14} color={pageColors.white} />
+    <LinearGradient
+      colors={[theme.colors.background, "#F6EBE0", theme.colors.backgroundDeep]}
+      locations={[0, 0.46, 1]}
+      start={{ x: 0.4, y: 0 }}
+      end={{ x: 0.6, y: 1 }}
+      style={styles.screen}
+    >
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.pageTopRow}>
+          <View style={styles.titleWrap}>
+            <Text style={styles.pageTitle}>Profile</Text>
+            <Text style={styles.pageSubtitle}>Your identity, trail habits, and support circle.</Text>
           </View>
-        </TouchableOpacity>
 
-        <Text style={styles.userName}>Melissa W.</Text>
-        
-        {/* New Bio Section */}
-        <Text style={styles.bioText}>
-          Full Stack Engineering student building cool things. Always ready for a trail walk!
-        </Text>
-
-        {/* New Location Section (Private) */}
-        <View style={styles.locationRow}>
-          <Feather name="map-pin" size={14} color={pageColors.coolSteel} />
-          <Text style={styles.locationText}>Tulsa, OK <Text style={styles.privateTag}>(Private)</Text></Text>
+          <Pressable style={styles.alertButton} onPress={onOpenAlerts}>
+            <Feather name="bell" size={18} color={theme.colors.white} />
+            {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
+          </Pressable>
         </View>
 
-      </View>
+        <LinearGradient
+          colors={[theme.colors.surface, theme.colors.surfaceWarm]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.heroCard}
+        >
+          <View style={styles.heroTopRow}>
+            <View style={styles.avatarWrap}>
+              <LinearGradient
+                colors={[theme.colors.brandBright, theme.colors.brand]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.avatarBadge}
+              >
+                <Text style={styles.avatarText}>{getInitials(profile)}</Text>
+              </LinearGradient>
+            </View>
 
-      {/* --- STATS ROW --- */}
-      <View style={styles.statsRow}>
-        <View style={[styles.bubbleCard, styles.halfCard]}>
-          <Text style={styles.statNumber}>142</Text>
-          <Text style={styles.statLabel}>Hours on Trail</Text>
-        </View>
-        <View style={[styles.bubbleCard, styles.halfCard]}>
-          <Text style={styles.statNumber}>48</Text>
-          <Text style={styles.statLabel}>Safe Journeys</Text>
-        </View>
-      </View>
+            <Pressable style={styles.settingsShortcut} onPress={onOpenSettings}>
+              <Feather name="sliders" size={18} color={theme.colors.brandDeep} />
+            </Pressable>
+          </View>
 
-      {/* --- GOALS WIDGET (Now with Progress Ring!) --- */}
-      <View style={[styles.bubbleCard, styles.goalCard]}>
-        <Text style={styles.cardTitle}>Weekly Goal</Text>
-        
-        {/* The CSS Progress Ring */}
-        <View style={styles.ringContainer}>
-          <View style={styles.progressRing}>
-            <View style={styles.innerRingContent}>
-              <Text style={styles.ringPercentage}>75%</Text>
-              <Text style={styles.ringSubtext}>Completed</Text>
+          <View style={styles.heroCopy}>
+            <Text style={styles.userName}>
+              {profile.firstName} {profile.lastName}
+            </Text>
+            <Text style={styles.userHeadline}>{profile.headline}</Text>
+            <Text style={styles.bioText}>{profile.bio}</Text>
+          </View>
+
+          <View style={styles.metaChipRow}>
+            <View style={styles.metaChip}>
+              <Feather name="map-pin" size={14} color={theme.colors.textSoft} />
+              <Text style={styles.metaChipText}>{profile.city}</Text>
+            </View>
+            <View style={styles.metaChip}>
+              <Feather name="shield" size={14} color={theme.colors.textSoft} />
+              <Text style={styles.metaChipText}>{profile.privacyLabel}</Text>
             </View>
           </View>
-        </View>
+        </LinearGradient>
 
-        <Text style={styles.progressText}>15 / 20 Miles</Text>
-      </View>
-
-      {/* --- TRUSTED CONTACTS WIDGET --- */}
-      <TouchableOpacity style={styles.bubbleCard}>
-        <View style={styles.contactRow}>
-          <View>
-            <Text style={styles.cardTitle}>Trusted Contacts (3)</Text>
-            <Text style={styles.cardSubtext}>Tap to manage your safety network</Text>
+        <View style={styles.metricsRow}>
+          <View style={styles.metricCard}>
+            <Text style={styles.metricValue}>{stats.safeJourneys}</Text>
+            <Text style={styles.metricLabel}>Safe journeys</Text>
           </View>
-          <Feather name="chevron-right" size={24} color={pageColors.coolSteel} />
+          <View style={styles.metricCard}>
+            <Text style={styles.metricValue}>{stats.hoursOutside.toFixed(0)}h</Text>
+            <Text style={styles.metricLabel}>Hours outside</Text>
+          </View>
+          <View style={styles.metricCard}>
+            <Text style={styles.metricValue}>{stats.currentStreakDays}</Text>
+            <Text style={styles.metricLabel}>Day streak</Text>
+          </View>
         </View>
-      </TouchableOpacity>
 
-    </ScrollView>
+        <View style={styles.card}>
+          <View style={styles.cardHeaderRow}>
+            <Text style={styles.cardTitle}>Weekly momentum</Text>
+            <Pressable onPress={onOpenStats} style={styles.inlineAction}>
+              <Text style={styles.inlineActionText}>See full stats</Text>
+            </Pressable>
+          </View>
+
+          <Text style={styles.goalValue}>
+            {stats.milesThisWeek.toFixed(1)} / {stats.weeklyGoalMiles} miles
+          </Text>
+          <View style={styles.progressTrack}>
+            <View style={[styles.progressFill, { width: `${weeklyProgress}%` }]} />
+          </View>
+          <Text style={styles.cardBodyText}>
+            {profile.nextMilestone} is next. Your favorite route right now is {stats.favoriteRouteTitle}.
+          </Text>
+        </View>
+
+        <View style={styles.card}>
+          <View style={styles.cardHeaderRow}>
+            <Text style={styles.cardTitle}>Safety network</Text>
+            <Pressable onPress={onOpenSettings} style={styles.inlineAction}>
+              <Text style={styles.inlineActionText}>Manage contacts</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.contactHero}>
+            <View style={styles.contactHeroCopy}>
+              <Text style={styles.contactHeroLabel}>Primary check-in contact</Text>
+              <Text style={styles.contactHeroName}>{primaryContactName}</Text>
+              <Text style={styles.cardBodyText}>
+                {trustedContacts.length} people are ready to receive updates if something changes mid-route.
+              </Text>
+            </View>
+            <View style={styles.contactCountBadge}>
+              <Text style={styles.contactCountBadgeText}>{trustedContacts.length}</Text>
+            </View>
+          </View>
+
+          <View style={styles.contactList}>
+            {trustedContacts.slice(0, 3).map((contact) => (
+              <View key={contact.id} style={styles.contactRow}>
+                <View style={styles.contactAvatar}>
+                  <Text style={styles.contactAvatarText}>
+                    {contact.firstName[0]}
+                    {contact.lastName[0]}
+                  </Text>
+                </View>
+                <View style={styles.contactCopy}>
+                  <Text style={styles.contactName}>
+                    {contact.firstName} {contact.lastName}
+                  </Text>
+                  <Text style={styles.contactMeta}>
+                    {contact.note} • {contact.phone}
+                  </Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Linked features</Text>
+          <View style={styles.linkGrid}>
+            <Pressable style={styles.linkCard} onPress={onOpenRoutes}>
+              <Feather name="map" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Routes</Text>
+              <Text style={styles.linkBody}>Open favorites and route reviews.</Text>
+            </Pressable>
+            <Pressable style={styles.linkCard} onPress={onOpenStartJourney}>
+              <Feather name="navigation" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Start journey</Text>
+              <Text style={styles.linkBody}>Launch a trip with your saved defaults.</Text>
+            </Pressable>
+            <Pressable style={styles.linkCard} onPress={onOpenStats}>
+              <Feather name="bar-chart-2" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Progress</Text>
+              <Text style={styles.linkBody}>Review pace, completion, and streaks.</Text>
+            </Pressable>
+            <Pressable style={styles.linkCard} onPress={onOpenSettings}>
+              <Feather name="settings" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Preferences</Text>
+              <Text style={styles.linkBody}>
+                {settings.autoShareLocation ? "Auto-share enabled" : "Auto-share disabled"} and privacy controls.
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <View style={styles.footerNote}>
+          <Text style={styles.footerNoteText}>
+            Member since {profile.memberSince}. Default mode is {settings.defaultJourneyMode}.
+          </Text>
+        </View>
+      </ScrollView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: pageColors.papaya, // The warm new background
-  },
-  scrollContent: {
-    padding: 20,
-    paddingTop: 28,
-    gap: 16, 
-  },
+  screen: { flex: 1 },
+  content: { padding: 20, paddingTop: 28, gap: 16 },
   pageTopRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    marginBottom: 4,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 16,
   },
-  pageTopSpacer: {
-    flex: 1,
+  titleWrap: { flex: 1, gap: 6 },
+  pageTitle: {
+    fontSize: 34,
+    lineHeight: 38,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  pageSubtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
   },
   alertButton: {
-    minWidth: 60,
+    minWidth: 56,
     minHeight: 46,
-    paddingHorizontal: 8,
-    paddingVertical: 11,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#DE8558',
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.brand,
     borderWidth: 1,
-    borderColor: '#CA7449',
-    position: 'relative',
-    shadowColor: '#CA7449',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.22,
-    shadowRadius: 16,
-    elevation: 4,
+    borderColor: theme.colors.brandDeep,
+    position: "relative",
   },
   alertDot: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
+    position: "absolute",
+    top: 9,
+    right: 9,
     width: 8,
     height: 8,
     borderRadius: 999,
-    backgroundColor: pageColors.lightGreen,
+    backgroundColor: theme.colors.accentLime,
   },
-  bubbleCard: {
-    backgroundColor: pageColors.white,
-    borderRadius: 24, 
-    padding: 20,
-    shadowColor: pageColors.charcoal, 
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4, 
+  heroCard: {
+    borderRadius: 28,
+    padding: 22,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 16,
   },
-  
-  // Header Styles
-  headerCard: {
-    alignItems: 'center',
-    paddingVertical: 30,
-    position: 'relative', // Allows absolute positioning of the edit button
+  heroTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
   },
-  editButton: {
-    position: 'absolute',
-    top: 20,
-    right: 20,
-    padding: 8,
-    backgroundColor: pageColors.papaya, // Soft background for the button
-    borderRadius: 20,
+  avatarWrap: {
+    borderRadius: 999,
+    padding: 4,
+    backgroundColor: "rgba(255,255,255,0.55)",
   },
-  avatarContainer: {
-    position: 'relative',
-    marginBottom: 16,
+  avatarBadge: {
+    width: 84,
+    height: 84,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
   },
-  avatarPlaceholder: {
-    width: 90,
-    height: 90,
-    borderRadius: 45,
-    backgroundColor: pageColors.coolSteel, 
+  avatarText: {
+    fontSize: 28,
+    fontWeight: "900",
+    color: theme.colors.white,
   },
-  cameraBadge: {
-    position: 'absolute',
-    bottom: 0,
-    right: 0,
-    backgroundColor: pageColors.tangerine,
-    padding: 8,
-    borderRadius: 15,
-    borderWidth: 3,
-    borderColor: pageColors.white,
+  settingsShortcut: {
+    width: 44,
+    height: 44,
+    borderRadius: 999,
+    backgroundColor: theme.colors.surfaceWarm,
+    alignItems: "center",
+    justifyContent: "center",
   },
+  heroCopy: { gap: 8 },
   userName: {
-    fontSize: 26,
-    fontWeight: 'bold',
-    color: pageColors.charcoal,
-    marginBottom: 8,
+    fontSize: 30,
+    lineHeight: 34,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  userHeadline: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: theme.colors.brandDeep,
   },
   bioText: {
     fontSize: 14,
-    color: pageColors.charcoal,
-    textAlign: 'center',
-    paddingHorizontal: 20,
-    marginBottom: 12,
     lineHeight: 20,
+    color: theme.colors.textSoft,
   },
-  locationRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    backgroundColor: pageColors.papaya,
+  metaChipRow: {
+    gap: 10,
+  },
+  metaChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
     paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 20,
+    paddingVertical: 10,
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(255,255,255,0.72)",
   },
-  locationText: {
+  metaChipText: {
+    flex: 1,
     fontSize: 13,
-    color: pageColors.charcoal,
-    fontWeight: '500',
+    lineHeight: 18,
+    fontWeight: "700",
+    color: theme.colors.text,
   },
-  privateTag: {
-    color: pageColors.coolSteel,
-    fontStyle: 'italic',
+  metricsRow: {
+    flexDirection: "row",
+    gap: 12,
   },
-
-  // Stats Styles
-  statsRow: {
-    flexDirection: 'row',
+  metricCard: {
+    flex: 1,
+    backgroundColor: theme.colors.surface,
+    borderRadius: 22,
+    padding: 18,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    alignItems: "center",
+    gap: 6,
+  },
+  metricValue: {
+    fontSize: 28,
+    lineHeight: 32,
+    fontWeight: "900",
+    color: theme.colors.brand,
+  },
+  metricLabel: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+    textAlign: "center",
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 26,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
     gap: 16,
   },
-  halfCard: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  statNumber: {
-    fontSize: 32,
-    fontWeight: '900',
-    color: pageColors.tangerine, // Peachy pop for stats
-  },
-  statLabel: {
-    fontSize: 13,
-    color: pageColors.coolSteel,
-    marginTop: 4,
-    fontWeight: '700',
-  },
-
-  // Goals & Progress Ring Styles
-  goalCard: {
-    alignItems: 'center',
+  cardHeaderRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
   },
   cardTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    color: pageColors.charcoal,
-    marginBottom: 4,
+    flex: 1,
+    fontSize: 21,
+    fontWeight: "900",
+    color: theme.colors.text,
   },
-  cardSubtext: {
-    color: pageColors.coolSteel,
-    fontSize: 13,
-    marginTop: 2,
+  inlineAction: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceWarm,
   },
-  ringContainer: {
-    marginVertical: 20,
-  },
-  progressRing: {
-    width: 140,
-    height: 140,
-    borderRadius: 70,
-    borderWidth: 12,
-    // The "unfilled" track color
-    borderColor: pageColors.papaya, 
-    // The "filled" progress colors!
-    borderTopColor: pageColors.lightGreen, 
-    borderRightColor: pageColors.tangerine,
-    justifyContent: 'center',
-    alignItems: 'center',
-    // Rotate the ring so the "fill" starts at the top
-    transform: [{ rotate: '-45deg' }], 
-  },
-  innerRingContent: {
-    // Counter-rotate the text so it isn't sideways inside the ring
-    transform: [{ rotate: '45deg' }], 
-    alignItems: 'center',
-  },
-  ringPercentage: {
-    fontSize: 28,
-    fontWeight: 'bold',
-    color: pageColors.charcoal,
-  },
-  ringSubtext: {
+  inlineActionText: {
     fontSize: 12,
-    color: pageColors.coolSteel,
-    fontWeight: '600',
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
   },
-  progressText: {
-    fontSize: 16,
-    color: pageColors.charcoal,
-    fontWeight: '600',
+  goalValue: {
+    fontSize: 26,
+    lineHeight: 30,
+    fontWeight: "900",
+    color: theme.colors.text,
   },
-
-  // Contacts Row
+  progressTrack: {
+    height: 12,
+    borderRadius: 999,
+    backgroundColor: "rgba(222,133,88,0.14)",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+    backgroundColor: theme.colors.brand,
+  },
+  cardBodyText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
+  },
+  contactHero: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+  },
+  contactHeroCopy: { flex: 1, gap: 6 },
+  contactHeroLabel: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  contactHeroName: {
+    fontSize: 23,
+    lineHeight: 28,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  contactCountBadge: {
+    width: 54,
+    height: 54,
+    borderRadius: 999,
+    backgroundColor: theme.colors.accentLime,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  contactCountBadgeText: {
+    fontSize: 22,
+    fontWeight: "900",
+    color: "#4F5A22",
+  },
+  contactList: { gap: 12 },
   contactRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    padding: 14,
+    borderRadius: 20,
+    backgroundColor: theme.colors.backgroundAlt,
+  },
+  contactAvatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 999,
+    backgroundColor: theme.colors.brandBright,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  contactAvatarText: {
+    fontSize: 14,
+    fontWeight: "900",
+    color: theme.colors.white,
+  },
+  contactCopy: { flex: 1, gap: 4 },
+  contactName: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  contactMeta: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
+  linkGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  linkCard: {
+    width: "47%",
+    borderRadius: 22,
+    padding: 16,
+    backgroundColor: theme.colors.backgroundAlt,
+    gap: 8,
+  },
+  linkTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  linkBody: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
+  footerNote: {
+    paddingHorizontal: 4,
+    paddingBottom: 12,
+  },
+  footerNoteText: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textMuted,
+    textAlign: "center",
   },
 });

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
+import AnimatedWayPointLogo from "../components/AnimatedWayPointLogo";
 import { theme } from "../styles/theme";
 import type {
   StatsSnapshot,
@@ -60,7 +61,12 @@ export default function ProfileScreen({
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <View style={styles.pageTopRow}>
           <View style={styles.titleWrap}>
-            <Text style={styles.pageTitle}>Profile</Text>
+            <View style={styles.headerTitleRow}>
+              <View style={styles.headerLogoWrap}>
+                <AnimatedWayPointLogo size={70} />
+              </View>
+              <Text style={styles.pageTitle}>Profile</Text>
+            </View>
             <Text style={styles.pageSubtitle}>Your identity, trail habits, and support circle.</Text>
           </View>
 
@@ -238,6 +244,17 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   titleWrap: { flex: 1, gap: 6 },
+  headerTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  headerLogoWrap: {
+    width: 62,
+    height: 62,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   pageTitle: {
     fontSize: 34,
     lineHeight: 38,

--- a/apps/mobile/src/screens/RoutesScreen.tsx
+++ b/apps/mobile/src/screens/RoutesScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import AnimatedWayPointLogo from "../components/AnimatedWayPointLogo";
 import { theme } from "../styles/theme";
 
 type RouteSectionKey = "saved" | "popular" | "reviewed" | "nearby";
@@ -644,8 +645,12 @@ export function RoutesScreen({
         ) : null}
         <View style={styles.pageIntroRow}>
           <View style={styles.pageIntro}>
-            <Text style={styles.pageEyebrow}>Explore</Text>
-            <Text style={styles.pageTitle}>Routes</Text>
+            <View style={styles.pageTitleRow}>
+              <View style={styles.pageLogoWrap}>
+                <AnimatedWayPointLogo size={70} />
+              </View>
+              <Text style={styles.pageTitle}>Routes</Text>
+            </View>
             <Text style={styles.pageSubtitle}>
               Find a route that feels comfortable, safe, and right for your day.
             </Text>
@@ -1084,12 +1089,16 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     gap: 14,
   },
-  pageEyebrow: {
-    fontSize: 11,
-    fontWeight: "800",
-    letterSpacing: 1.8,
-    textTransform: "uppercase",
-    color: theme.colors.textMuted,
+  pageTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  pageLogoWrap: {
+    width: 62,
+    height: 62,
+    alignItems: "center",
+    justifyContent: "center",
   },
   pageTitle: {
     fontSize: 34,

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
+import AnimatedWayPointLogo from "../components/AnimatedWayPointLogo";
 import { theme } from "../styles/theme";
 import type { TrustedContact, UserSettings } from "../types/appData";
 
@@ -93,7 +94,12 @@ export default function SettingsScreen({
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <View style={styles.pageHeaderRow}>
           <View style={styles.titleWrap}>
-            <Text style={styles.pageHeader}>Settings</Text>
+            <View style={styles.headerTitleRow}>
+              <View style={styles.headerLogoWrap}>
+                <AnimatedWayPointLogo size={70} />
+              </View>
+              <Text style={styles.pageHeader}>Settings</Text>
+            </View>
             <Text style={styles.pageSubheader}>
               Fine tune privacy, alerts, and the people your journeys depend on.
             </Text>
@@ -273,6 +279,17 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   titleWrap: { flex: 1, gap: 6 },
+  headerTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  headerLogoWrap: {
+    width: 62,
+    height: 62,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   pageHeader: {
     fontSize: 34,
     lineHeight: 38,

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,163 +1,535 @@
-import React, { useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Switch } from 'react-native';
-import { Feather } from '@expo/vector-icons';
+import React from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import { theme } from "../styles/theme";
+import type { TrustedContact, UserSettings } from "../types/appData";
 
-const pageColors = {
-  lightGreen: '#B2EF91',
-  tangerine: '#FA9372',
-  charcoal: '#2C3E50',
-  papaya: '#FDEBD0',
-  coolSteel: '#77A0A9',
-  white: '#FFFFFF',
-};
+type ToggleKey =
+  | "autoShareLocation"
+  | "pushNotifications"
+  | "routeDeviationAlerts"
+  | "missedCheckInAlerts"
+  | "weeklyDigest";
 
 type SettingsScreenProps = {
+  settings: UserSettings;
+  trustedContacts: TrustedContact[];
+  urgentAlertsCount?: number;
   onOpenAlerts?: () => void;
+  onOpenProfile?: () => void;
+  onOpenStats?: () => void;
+  onOpenRoutes?: () => void;
+  onOpenStartJourney?: () => void;
+  onToggleSetting: (key: ToggleKey) => void;
+  onCycleLocationVisibility: () => void;
+  onCycleDefaultJourneyMode: () => void;
+  onPromoteContact: (contactId: string) => void;
   hasAlertIndicator?: boolean;
 };
 
+const toggleRows: Array<{
+  key: ToggleKey;
+  title: string;
+  description: string;
+}> = [
+  {
+    key: "autoShareLocation",
+    title: "Auto-share location",
+    description: "Start journeys with location updates ready for trusted contacts.",
+  },
+  {
+    key: "pushNotifications",
+    title: "Push notifications",
+    description: "Get reminders, safety updates, and route changes on time.",
+  },
+  {
+    key: "routeDeviationAlerts",
+    title: "Off-route alerts",
+    description: "Notify your support network if a trip strays from the planned route.",
+  },
+  {
+    key: "missedCheckInAlerts",
+    title: "Missed check-ins",
+    description: "Escalate when a check-in window passes without a response.",
+  },
+  {
+    key: "weeklyDigest",
+    title: "Weekly recap",
+    description: "Receive a simple summary of goals, streaks, and journey completion.",
+  },
+];
+
 export default function SettingsScreen({
+  settings,
+  trustedContacts,
+  urgentAlertsCount = 0,
   onOpenAlerts,
+  onOpenProfile,
+  onOpenStats,
+  onOpenRoutes,
+  onOpenStartJourney,
+  onToggleSetting,
+  onCycleLocationVisibility,
+  onCycleDefaultJourneyMode,
+  onPromoteContact,
   hasAlertIndicator = false,
 }: SettingsScreenProps) {
-  // Local state for our toggle switches
-  const [autoShare, setAutoShare] = useState(true);
-  const [pushNotifs, setPushNotifs] = useState(true);
-
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.scrollContent}>
-      <View style={styles.pageHeaderRow}>
-        <Text style={styles.pageHeader}>Settings</Text>
-        <TouchableOpacity style={styles.alertButton} onPress={onOpenAlerts}>
-          <Feather name="bell" size={18} color={pageColors.white} />
-          {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
-        </TouchableOpacity>
-      </View>
-
-      {/* --- SAFETY PREFERENCES WIDGET --- */}
-      <View style={styles.bubbleCard}>
-        <View style={styles.cardHeader}>
-          <Feather name="shield" size={24} color={pageColors.tangerine} />
-          <Text style={styles.cardTitle}>Safety Alerts</Text>
-        </View>
-
-        <View style={styles.settingRow}>
-          <View>
-            <Text style={styles.settingText}>Auto-Share Location</Text>
-            <Text style={styles.settingSubtext}>When starting a new journey</Text>
+    <LinearGradient
+      colors={[theme.colors.background, "#F4E7DA", theme.colors.backgroundDeep]}
+      locations={[0, 0.48, 1]}
+      start={{ x: 0.4, y: 0 }}
+      end={{ x: 0.6, y: 1 }}
+      style={styles.screen}
+    >
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.pageHeaderRow}>
+          <View style={styles.titleWrap}>
+            <Text style={styles.pageHeader}>Settings</Text>
+            <Text style={styles.pageSubheader}>
+              Fine tune privacy, alerts, and the people your journeys depend on.
+            </Text>
           </View>
-          <Switch 
-            value={autoShare} 
-            onValueChange={setAutoShare}
-            trackColor={{ false: pageColors.coolSteel, true: pageColors.lightGreen }}
-          />
-        </View>
-      </View>
 
-      {/* --- TRUSTED CONTACTS WIDGET --- */}
-      <View style={styles.bubbleCard}>
-        <View style={styles.cardHeader}>
-          <Feather name="users" size={24} color={pageColors.coolSteel} />
-          <Text style={styles.cardTitle}>Trusted Contacts</Text>
+          <Pressable style={styles.alertButton} onPress={onOpenAlerts}>
+            <Feather name="bell" size={18} color={theme.colors.white} />
+            {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
+          </Pressable>
         </View>
 
-        {/* Mock Contact 1 */}
-        <View style={styles.contactRow}>
-          <View style={styles.contactInfo}>
-            <View style={styles.contactAvatar}>
-              <Text style={styles.avatarInitial}>J</Text>
+        <LinearGradient
+          colors={[theme.colors.surface, theme.colors.surfaceWarm]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.heroCard}
+        >
+          <View style={styles.heroTopRow}>
+            <View>
+              <Text style={styles.heroEyebrow}>Safety coverage</Text>
+              <Text style={styles.heroTitle}>
+                {settings.routeDeviationAlerts && settings.missedCheckInAlerts
+                  ? "Fully armed for route monitoring"
+                  : "Some safety automations are paused"}
+              </Text>
             </View>
-            <Text style={styles.settingText}>Jane Doe</Text>
+            <View style={styles.heroBadge}>
+              <Text style={styles.heroBadgeText}>{urgentAlertsCount}</Text>
+              <Text style={styles.heroBadgeLabel}>open alerts</Text>
+            </View>
           </View>
-          <TouchableOpacity>
-            <Feather name="edit-2" size={18} color={pageColors.charcoal} />
-          </TouchableOpacity>
+
+          <View style={styles.heroPillRow}>
+            <View style={styles.heroPill}>
+              <Text style={styles.heroPillLabel}>Visibility</Text>
+              <Text style={styles.heroPillValue}>{settings.locationVisibility}</Text>
+            </View>
+            <View style={styles.heroPill}>
+              <Text style={styles.heroPillLabel}>Default mode</Text>
+              <Text style={styles.heroPillValue}>{settings.defaultJourneyMode}</Text>
+            </View>
+          </View>
+        </LinearGradient>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Core preferences</Text>
+          <View style={styles.toggleList}>
+            {toggleRows.map((item) => (
+              <View key={item.key} style={styles.toggleRow}>
+                <View style={styles.toggleCopy}>
+                  <Text style={styles.toggleTitle}>{item.title}</Text>
+                  <Text style={styles.toggleDescription}>{item.description}</Text>
+                </View>
+                <Switch
+                  value={settings[item.key]}
+                  onValueChange={() => onToggleSetting(item.key)}
+                  trackColor={{
+                    false: theme.colors.inkSoft,
+                    true: theme.colors.accentLime,
+                  }}
+                  thumbColor={theme.colors.white}
+                />
+              </View>
+            ))}
+          </View>
         </View>
 
-        <TouchableOpacity style={styles.addButton}>
-          <Feather name="plus" size={20} color={pageColors.charcoal} />
-          <Text style={styles.addButtonText}>Add New Contact</Text>
-        </TouchableOpacity>
-      </View>
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Privacy and journey defaults</Text>
 
-      {/* --- NOTIFICATIONS WIDGET --- */}
-      <View style={styles.bubbleCard}>
-        <View style={styles.cardHeader}>
-          <Feather name="bell" size={24} color={pageColors.tangerine} />
-          <Text style={styles.cardTitle}>Notifications</Text>
+          <Pressable style={styles.preferenceRow} onPress={onCycleLocationVisibility}>
+            <View style={styles.preferenceCopy}>
+              <Text style={styles.preferenceTitle}>Location visibility</Text>
+              <Text style={styles.preferenceDescription}>
+                Decide when your live position is visible to others.
+              </Text>
+            </View>
+            <View style={styles.preferenceBadge}>
+              <Text style={styles.preferenceBadgeText}>{settings.locationVisibility}</Text>
+            </View>
+          </Pressable>
+
+          <Pressable style={styles.preferenceRow} onPress={onCycleDefaultJourneyMode}>
+            <View style={styles.preferenceCopy}>
+              <Text style={styles.preferenceTitle}>Default journey mode</Text>
+              <Text style={styles.preferenceDescription}>
+                Pick the setup you want preselected when opening Start Journey.
+              </Text>
+            </View>
+            <View style={styles.preferenceBadge}>
+              <Text style={styles.preferenceBadgeText}>{settings.defaultJourneyMode}</Text>
+            </View>
+          </Pressable>
         </View>
 
-        <View style={styles.settingRow}>
-          <Text style={styles.settingText}>Push Notifications</Text>
-          <Switch 
-            value={pushNotifs} 
-            onValueChange={setPushNotifs}
-            trackColor={{ false: pageColors.coolSteel, true: pageColors.lightGreen }}
-          />
-        </View>
-      </View>
+        <View style={styles.card}>
+          <View style={styles.cardHeaderRow}>
+            <Text style={styles.cardTitle}>Trusted contacts</Text>
+            <Pressable onPress={onOpenProfile} style={styles.inlineAction}>
+              <Text style={styles.inlineActionText}>Back to profile</Text>
+            </Pressable>
+          </View>
 
-    </ScrollView>
+          <View style={styles.contactList}>
+            {trustedContacts.map((contact, index) => (
+              <View key={contact.id} style={styles.contactRow}>
+                <View style={styles.contactIdentity}>
+                  <View style={styles.contactAvatar}>
+                    <Text style={styles.contactAvatarText}>
+                      {contact.firstName[0]}
+                      {contact.lastName[0]}
+                    </Text>
+                  </View>
+                  <View style={styles.contactCopy}>
+                    <Text style={styles.contactName}>
+                      {contact.firstName} {contact.lastName}
+                    </Text>
+                    <Text style={styles.contactMeta}>
+                      {contact.note} • {contact.phone}
+                    </Text>
+                  </View>
+                </View>
+
+                <Pressable
+                  style={[
+                    styles.contactAction,
+                    index === 0 && styles.contactActionSelected,
+                  ]}
+                  onPress={() => onPromoteContact(contact.id)}
+                >
+                  <Text
+                    style={[
+                      styles.contactActionText,
+                      index === 0 && styles.contactActionTextSelected,
+                    ]}
+                  >
+                    {index === 0 ? "Primary" : "Make primary"}
+                  </Text>
+                </Pressable>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Linked pages</Text>
+          <View style={styles.linkRow}>
+            <Pressable style={styles.linkCard} onPress={onOpenStats}>
+              <Feather name="bar-chart-2" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Stats</Text>
+              <Text style={styles.linkBody}>Review completion and check-in rates.</Text>
+            </Pressable>
+            <Pressable style={styles.linkCard} onPress={onOpenRoutes}>
+              <Feather name="map" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Routes</Text>
+              <Text style={styles.linkBody}>Choose a route that matches your setup.</Text>
+            </Pressable>
+            <Pressable style={styles.linkCard} onPress={onOpenStartJourney}>
+              <Feather name="navigation" size={18} color={theme.colors.brandDeep} />
+              <Text style={styles.linkTitle}>Start Journey</Text>
+              <Text style={styles.linkBody}>Use the defaults you just updated.</Text>
+            </Pressable>
+          </View>
+        </View>
+      </ScrollView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: pageColors.papaya },
-  scrollContent: { padding: 20, paddingTop: 28, gap: 16 },
+  screen: { flex: 1 },
+  content: { padding: 20, paddingTop: 28, gap: 16 },
   pageHeaderRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 14,
-    marginBottom: 8,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 16,
   },
-  pageHeader: { fontSize: 32, fontWeight: 'bold', color: pageColors.charcoal, flex: 1 },
+  titleWrap: { flex: 1, gap: 6 },
+  pageHeader: {
+    fontSize: 34,
+    lineHeight: 38,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  pageSubheader: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
+  },
   alertButton: {
-    minWidth: 60,
+    minWidth: 56,
     minHeight: 46,
-    paddingHorizontal: 8,
-    paddingVertical: 11,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#DE8558',
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.brand,
     borderWidth: 1,
-    borderColor: '#CA7449',
-    position: 'relative',
-    shadowColor: '#CA7449',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.22,
-    shadowRadius: 16,
-    elevation: 4,
+    borderColor: theme.colors.brandDeep,
+    position: "relative",
   },
   alertDot: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
+    position: "absolute",
+    top: 9,
+    right: 9,
     width: 8,
     height: 8,
     borderRadius: 999,
-    backgroundColor: pageColors.lightGreen,
+    backgroundColor: theme.colors.accentLime,
   },
-  bubbleCard: {
-    backgroundColor: pageColors.white,
-    borderRadius: 24,
+  heroCard: {
+    borderRadius: 28,
+    padding: 22,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 16,
+  },
+  heroTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 16,
+  },
+  heroEyebrow: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  heroTitle: {
+    marginTop: 6,
+    fontSize: 26,
+    lineHeight: 30,
+    fontWeight: "900",
+    color: theme.colors.text,
+    maxWidth: 230,
+  },
+  heroBadge: {
+    minWidth: 84,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 22,
+    backgroundColor: theme.colors.surfaceWarm,
+    alignItems: "center",
+    gap: 2,
+  },
+  heroBadgeText: {
+    fontSize: 22,
+    fontWeight: "900",
+    color: theme.colors.brandDeep,
+  },
+  heroBadgeLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+  },
+  heroPillRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  heroPill: {
+    flex: 1,
+    borderRadius: 18,
+    padding: 14,
+    backgroundColor: "rgba(255,255,255,0.72)",
+    gap: 6,
+  },
+  heroPillLabel: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  heroPillValue: {
+    fontSize: 15,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 26,
     padding: 20,
-    shadowColor: pageColors.charcoal,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 16,
   },
-  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 12, marginBottom: 20 },
-  cardTitle: { fontSize: 20, fontWeight: 'bold', color: pageColors.charcoal },
-  settingRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#f0f0f0' },
-  settingText: { fontSize: 16, color: pageColors.charcoal, fontWeight: '500' },
-  settingSubtext: { fontSize: 12, color: pageColors.coolSteel, marginTop: 4 },
-  contactRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#f0f0f0' },
-  contactInfo: { flexDirection: 'row', alignItems: 'center', gap: 12 },
-  contactAvatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: pageColors.lightGreen, justifyContent: 'center', alignItems: 'center' },
-  avatarInitial: { color: pageColors.charcoal, fontWeight: 'bold', fontSize: 16 },
-  addButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, marginTop: 16, paddingVertical: 12, backgroundColor: pageColors.papaya, borderRadius: 16 },
-  addButtonText: { color: pageColors.charcoal, fontWeight: 'bold', fontSize: 16 },
+  cardTitle: {
+    fontSize: 21,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  toggleList: { gap: 12 },
+  toggleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 14,
+    padding: 14,
+    borderRadius: 20,
+    backgroundColor: theme.colors.backgroundAlt,
+  },
+  toggleCopy: { flex: 1, gap: 4 },
+  toggleTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  toggleDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
+  preferenceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 14,
+    padding: 14,
+    borderRadius: 20,
+    backgroundColor: theme.colors.backgroundAlt,
+  },
+  preferenceCopy: { flex: 1, gap: 4 },
+  preferenceTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  preferenceDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
+  preferenceBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceWarm,
+  },
+  preferenceBadgeText: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  cardHeaderRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+  },
+  inlineAction: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceWarm,
+  },
+  inlineActionText: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  contactList: { gap: 12 },
+  contactRow: {
+    gap: 12,
+    padding: 14,
+    borderRadius: 20,
+    backgroundColor: theme.colors.backgroundAlt,
+  },
+  contactIdentity: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  contactAvatar: {
+    width: 42,
+    height: 42,
+    borderRadius: 999,
+    backgroundColor: theme.colors.brandBright,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  contactAvatarText: {
+    fontSize: 14,
+    fontWeight: "900",
+    color: theme.colors.white,
+  },
+  contactCopy: { flex: 1, gap: 4 },
+  contactName: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  contactMeta: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
+  contactAction: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceWarm,
+  },
+  contactActionSelected: {
+    backgroundColor: theme.colors.accentLime,
+  },
+  contactActionText: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  contactActionTextSelected: {
+    color: "#4F5A22",
+  },
+  linkRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  linkCard: {
+    width: "47%",
+    borderRadius: 22,
+    padding: 16,
+    backgroundColor: theme.colors.backgroundAlt,
+    gap: 8,
+  },
+  linkTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  linkBody: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
 });

--- a/apps/mobile/src/screens/StartJourneyScreen.tsx
+++ b/apps/mobile/src/screens/StartJourneyScreen.tsx
@@ -13,12 +13,15 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import { theme } from "../styles/theme";
 import type { SavedRouteStartPreset } from "./RoutesScreen";
+import type { TrustedContact, UserSettings } from "../types/appData";
 
 type StartJourneyScreenProps = {
   onStartJourney?: (journeyConfig: StartJourneyConfig) => void;
   onOpenAlerts?: () => void;
   onOpenProfile?: () => void;
   initialRoutePreset?: SavedRouteStartPreset | null;
+  trustedContacts?: TrustedContact[];
+  defaultJourneyMode?: UserSettings["defaultJourneyMode"];
   hasAlertIndicator?: boolean;
 };
 
@@ -142,13 +145,32 @@ const journeySpeedMph: Record<JourneyType, number> = {
   bike: 10,
 };
 
+function mapTrustedContactsToEditableContacts(
+  contacts: TrustedContact[] | undefined,
+): EditableContact[] {
+  if (!contacts || contacts.length === 0) {
+    return initialTrustedContacts;
+  }
+
+  return contacts.map((contact) => ({
+    id: contact.id,
+    firstName: contact.firstName,
+    lastName: contact.lastName,
+    phone: contact.phone,
+    note: contact.note,
+  }));
+}
+
 export function StartJourneyScreen({
   onStartJourney,
   onOpenAlerts,
   onOpenProfile,
   initialRoutePreset = null,
+  trustedContacts,
+  defaultJourneyMode = "solo",
   hasAlertIndicator = false,
 }: StartJourneyScreenProps) {
+  const initialTrustedContactList = mapTrustedContactsToEditableContacts(trustedContacts);
   const safetyScrollRef = useRef<ScrollView | null>(null);
   const [journeyType, setJourneyType] = useState<JourneyType>("walk");
   const [measureType, setMeasureType] = useState<TripMeasure>("distance");
@@ -159,17 +181,19 @@ export function StartJourneyScreen({
   const [destinationLocation, setDestinationLocation] = useState("");
   const [locationMode, setLocationMode] = useState<LocationMode>("current");
   const [routeShape, setRouteShape] = useState<RouteShape>("oneWay");
-  const [groupJourneyEnabled, setGroupJourneyEnabled] = useState(false);
+  const [groupJourneyEnabled, setGroupJourneyEnabled] = useState(
+    defaultJourneyMode === "group",
+  );
   const [trustedContactList, setTrustedContactList] =
-    useState<EditableContact[]>(initialTrustedContacts);
+    useState<EditableContact[]>(initialTrustedContactList);
   const [groupMemberList, setGroupMemberList] =
     useState<EditableContact[]>(initialGroupMembers);
   const [includedSafetyIds, setIncludedSafetyIds] =
     useState<string[]>([...defaultIncludedSafetyIds]);
   const [selectedTrustedContactName, setSelectedTrustedContactName] =
     useState(
-      initialTrustedContacts[0]
-        ? `${initialTrustedContacts[0].firstName} ${initialTrustedContacts[0].lastName}`.trim()
+      initialTrustedContactList[0]
+        ? `${initialTrustedContactList[0].firstName} ${initialTrustedContactList[0].lastName}`.trim()
         : "",
     );
   const [safetyScrollX, setSafetyScrollX] = useState(0);
@@ -244,6 +268,20 @@ export function StartJourneyScreen({
       : initialRoutePreset?.routeName?.trim()
         ? initialRoutePreset.routeName
       : `${selectedJourney?.label ?? "Journey"} ${routeShape === "loop" ? "Loop" : "Route"}`;
+
+  useEffect(() => {
+    const nextTrustedContacts = mapTrustedContactsToEditableContacts(trustedContacts);
+    setTrustedContactList(nextTrustedContacts);
+    setSelectedTrustedContactName(
+      nextTrustedContacts[0]
+        ? `${nextTrustedContacts[0].firstName} ${nextTrustedContacts[0].lastName}`.trim()
+        : "",
+    );
+  }, [trustedContacts]);
+
+  useEffect(() => {
+    setGroupJourneyEnabled(defaultJourneyMode === "group");
+  }, [defaultJourneyMode]);
 
   useEffect(() => {
     if (!initialRoutePreset) {

--- a/apps/mobile/src/screens/StatisticsScreen.tsx
+++ b/apps/mobile/src/screens/StatisticsScreen.tsx
@@ -1,160 +1,488 @@
-import React from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
-import { Feather } from '@expo/vector-icons';
-
-const pageColors = {
-  lightGreen: '#B2EF91',
-  tangerine: '#FA9372',
-  charcoal: '#2C3E50',
-  papaya: '#FDEBD0',
-  coolSteel: '#77A0A9',
-  white: '#FFFFFF',
-};
+import React from "react";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Feather } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import { theme } from "../styles/theme";
+import type {
+  StatsSnapshot,
+  TrustedContact,
+  UserSettings,
+} from "../types/appData";
 
 type StatisticsScreenProps = {
+  stats: StatsSnapshot;
+  trustedContacts: TrustedContact[];
+  settings: UserSettings;
+  hasActiveJourney?: boolean;
+  urgentAlertsCount?: number;
   onOpenAlerts?: () => void;
+  onOpenRoutes?: () => void;
+  onOpenStartJourney?: () => void;
+  onOpenProfile?: () => void;
+  onOpenSettings?: () => void;
   hasAlertIndicator?: boolean;
 };
 
+function buildInsightChips(settings: UserSettings, trustedContacts: TrustedContact[]) {
+  return [
+    settings.autoShareLocation ? "Auto-share on" : "Auto-share off",
+    settings.routeDeviationAlerts ? "Off-route alerts on" : "Off-route alerts off",
+    `${trustedContacts.length} trusted contacts ready`,
+  ];
+}
+
 export default function StatisticsScreen({
+  stats,
+  trustedContacts,
+  settings,
+  hasActiveJourney = false,
+  urgentAlertsCount = 0,
   onOpenAlerts,
+  onOpenRoutes,
+  onOpenStartJourney,
+  onOpenProfile,
+  onOpenSettings,
   hasAlertIndicator = false,
 }: StatisticsScreenProps) {
+  const weeklyProgress = Math.min(100, Math.round((stats.milesThisWeek / stats.weeklyGoalMiles) * 100));
+  const monthlyJourneyGoal = 60;
+  const monthlyProgress = Math.min(100, Math.round((stats.safeJourneys / monthlyJourneyGoal) * 100));
+  const insightChips = buildInsightChips(settings, trustedContacts);
+
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.scrollContent}>
-      <View style={styles.pageHeaderRow}>
-        <Text style={styles.pageHeader}>Your Stats</Text>
-        <TouchableOpacity style={styles.alertButton} onPress={onOpenAlerts}>
-          <Feather name="bell" size={18} color={pageColors.white} />
-          {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
-        </TouchableOpacity>
-      </View>
-
-      {/* --- STREAKS WIDGET --- */}
-      <View style={styles.bubbleCard}>
-        <View style={styles.streakHeader}>
-          <Feather name="trending-up" size={32} color={pageColors.tangerine} />
-          <View>
-            <Text style={styles.streakNumber}>5 Days</Text>
-            <Text style={styles.streakLabel}>Current Trail Streak</Text>
+    <LinearGradient
+      colors={[theme.colors.background, "#F3E7D9", theme.colors.backgroundDeep]}
+      locations={[0, 0.48, 1]}
+      start={{ x: 0.4, y: 0 }}
+      end={{ x: 0.6, y: 1 }}
+      style={styles.screen}
+    >
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.pageHeaderRow}>
+          <View style={styles.titleBlock}>
+            <Text style={styles.pageHeader}>Trail Stats</Text>
+            <Text style={styles.pageSubheader}>
+              A quick read on momentum, safety habits, and what to do next.
+            </Text>
           </View>
-        </View>
-      </View>
 
-      {/* --- ACTIVE GOALS WIDGET (With Edit Button) --- */}
-      <View style={styles.bubbleCard}>
-        <View style={styles.cardHeaderRow}>
-          <Text style={styles.cardTitle}>Weekly Goals</Text>
-          <TouchableOpacity style={styles.editIcon}>
-            <Feather name="sliders" size={18} color={pageColors.charcoal} />
-          </TouchableOpacity>
+          <Pressable style={styles.alertButton} onPress={onOpenAlerts}>
+            <Feather name="bell" size={18} color={theme.colors.white} />
+            {hasAlertIndicator ? <View style={styles.alertDot} /> : null}
+          </Pressable>
         </View>
 
-        <View style={styles.goalRow}>
-          <View>
-            <Text style={styles.settingText}>Distance</Text>
-            <Text style={styles.settingSubtext}>15 / 20 Miles</Text>
+        <LinearGradient
+          colors={[theme.colors.surface, theme.colors.surfaceWarm]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.heroCard}
+        >
+          <View style={styles.heroTopRow}>
+            <View>
+              <Text style={styles.heroEyebrow}>Weekly pace</Text>
+              <Text style={styles.heroValue}>
+                {stats.milesThisWeek.toFixed(1)} / {stats.weeklyGoalMiles} mi
+              </Text>
+            </View>
+            <View style={styles.heroBadge}>
+              <Text style={styles.heroBadgeText}>{weeklyProgress}%</Text>
+            </View>
           </View>
-          <Text style={styles.goalPercentage}>75%</Text>
+
+          <View style={styles.progressTrack}>
+            <View style={[styles.progressFill, { width: `${weeklyProgress}%` }]} />
+          </View>
+
+          <Text style={styles.heroCaption}>{stats.nextGoalLabel}</Text>
+
+          <View style={styles.insightChipRow}>
+            {insightChips.map((chip) => (
+              <View key={chip} style={styles.insightChip}>
+                <Text style={styles.insightChipText}>{chip}</Text>
+              </View>
+            ))}
+          </View>
+        </LinearGradient>
+
+        <View style={styles.metricsGrid}>
+          {[
+            { label: "Safe journeys", value: `${stats.safeJourneys}`, accent: theme.colors.brand },
+            { label: "Hours outside", value: `${stats.hoursOutside.toFixed(0)}h`, accent: theme.colors.ink },
+            { label: "Streak", value: `${stats.currentStreakDays} days`, accent: theme.colors.accentLime },
+            { label: "Alerts open", value: `${urgentAlertsCount}`, accent: theme.colors.accentCoral },
+          ].map((item) => (
+            <View key={item.label} style={styles.metricCard}>
+              <Text style={[styles.metricValue, { color: item.accent }]}>{item.value}</Text>
+              <Text style={styles.metricLabel}>{item.label}</Text>
+            </View>
+          ))}
         </View>
 
-        <View style={styles.goalRow}>
-          <View>
-            <Text style={styles.settingText}>Active Time</Text>
-            <Text style={styles.settingSubtext}>3 / 5 Hours</Text>
+        <View style={styles.card}>
+          <View style={styles.cardHeaderRow}>
+            <Text style={styles.cardTitle}>Safety reliability</Text>
+            <Pressable onPress={onOpenSettings} style={styles.inlineAction}>
+              <Text style={styles.inlineActionText}>Tune settings</Text>
+            </Pressable>
           </View>
-          <Text style={styles.goalPercentage}>60%</Text>
+
+          <View style={styles.reliabilityRow}>
+            <View style={styles.reliabilityMetric}>
+              <Text style={styles.reliabilityLabel}>Route completion</Text>
+              <Text style={styles.reliabilityValue}>{stats.completionRate}%</Text>
+            </View>
+            <View style={styles.reliabilityMetric}>
+              <Text style={styles.reliabilityLabel}>Check-in response</Text>
+              <Text style={styles.reliabilityValue}>{stats.checkInRate}%</Text>
+            </View>
+          </View>
+
+          <Text style={styles.cardBodyText}>
+            {settings.missedCheckInAlerts
+              ? "Missed check-in alerts are enabled, so your support network gets nudged if timing slips."
+              : "Missed check-in alerts are off right now, which lowers your safety coverage on longer trips."}
+          </Text>
         </View>
 
-        <TouchableOpacity style={styles.editGoalsButton}>
-          <Text style={styles.editGoalsText}>Adjust Goal Targets</Text>
-        </TouchableOpacity>
-      </View>
+        <View style={styles.card}>
+          <View style={styles.cardHeaderRow}>
+            <Text style={styles.cardTitle}>Route trends</Text>
+            <Pressable onPress={onOpenRoutes} style={styles.inlineAction}>
+              <Text style={styles.inlineActionText}>Open routes</Text>
+            </Pressable>
+          </View>
 
-      {/* --- MILESTONES WIDGET --- */}
-      <View style={styles.bubbleCard}>
-        <Text style={styles.cardTitle}>Milestones</Text>
-        
-        <View style={styles.milestoneRow}>
-          <View style={styles.iconCircle}>
-            <Feather name="award" size={20} color={pageColors.white} />
+          <View style={styles.routeInsightRow}>
+            <View style={styles.routeInsightBlock}>
+              <Text style={styles.routeInsightLabel}>Favorite route</Text>
+              <Text style={styles.routeInsightValue}>{stats.favoriteRouteTitle}</Text>
+            </View>
+            <View style={styles.routeInsightBlock}>
+              <Text style={styles.routeInsightLabel}>Last journey</Text>
+              <Text style={styles.routeInsightValue}>{stats.lastJourneyLabel}</Text>
+            </View>
           </View>
-          <View>
-            <Text style={styles.settingText}>100 Miles Walked</Text>
-            <Text style={styles.settingSubtext}>Achieved Mar 15, 2026</Text>
+
+          <View style={styles.progressTrackMuted}>
+            <View style={[styles.progressFillMuted, { width: `${monthlyProgress}%` }]} />
           </View>
+          <Text style={styles.cardBodyText}>
+            You are at {monthlyProgress}% of this month&apos;s safe journey goal, with{" "}
+            {trustedContacts.length} trusted contacts ready to receive updates.
+          </Text>
         </View>
 
-      </View>
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Next action</Text>
+          <View style={styles.actionStack}>
+            <Pressable style={styles.primaryActionCard} onPress={onOpenStartJourney}>
+              <Text style={styles.primaryActionEyebrow}>
+                {hasActiveJourney ? "Journey in progress" : "Ready for another route?"}
+              </Text>
+              <Text style={styles.primaryActionTitle}>
+                {hasActiveJourney ? "Open your active trip" : "Start a new journey"}
+              </Text>
+              <Text style={styles.primaryActionText}>
+                Keep your streak moving with your favorite setup and current safety preferences.
+              </Text>
+            </Pressable>
 
-    </ScrollView>
+            <View style={styles.secondaryActionRow}>
+              <Pressable style={styles.secondaryActionCard} onPress={onOpenProfile}>
+                <Text style={styles.secondaryActionTitle}>Review profile</Text>
+                <Text style={styles.secondaryActionBody}>Check milestones and contact readiness.</Text>
+              </Pressable>
+              <Pressable style={styles.secondaryActionCard} onPress={onOpenSettings}>
+                <Text style={styles.secondaryActionTitle}>Refine alerts</Text>
+                <Text style={styles.secondaryActionBody}>Adjust notifications and privacy defaults.</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: pageColors.papaya },
-  scrollContent: { padding: 20, paddingTop: 28, gap: 16 },
+  screen: { flex: 1 },
+  content: { padding: 20, paddingTop: 28, gap: 16 },
   pageHeaderRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 14,
-    marginBottom: 8,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+    gap: 16,
   },
-  pageHeader: { fontSize: 32, fontWeight: 'bold', color: pageColors.charcoal, flex: 1 },
+  titleBlock: { flex: 1, gap: 6 },
+  pageHeader: {
+    fontSize: 34,
+    lineHeight: 38,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  pageSubheader: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
+  },
   alertButton: {
-    minWidth: 60,
+    minWidth: 56,
     minHeight: 46,
-    paddingHorizontal: 8,
-    paddingVertical: 11,
-    borderRadius: 20,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#DE8558',
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: theme.colors.brand,
     borderWidth: 1,
-    borderColor: '#CA7449',
-    position: 'relative',
-    shadowColor: '#CA7449',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.22,
-    shadowRadius: 16,
-    elevation: 4,
+    borderColor: theme.colors.brandDeep,
+    position: "relative",
   },
   alertDot: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
+    position: "absolute",
+    top: 9,
+    right: 9,
     width: 8,
     height: 8,
     borderRadius: 999,
-    backgroundColor: pageColors.lightGreen,
+    backgroundColor: theme.colors.accentLime,
   },
-  bubbleCard: {
-    backgroundColor: pageColors.white,
+  heroCard: {
+    borderRadius: 28,
+    padding: 22,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 16,
+  },
+  heroTopRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+  },
+  heroEyebrow: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  heroValue: {
+    marginTop: 6,
+    fontSize: 30,
+    lineHeight: 34,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  heroBadge: {
+    minWidth: 66,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.accentLime,
+    alignItems: "center",
+  },
+  heroBadgeText: {
+    fontSize: 18,
+    fontWeight: "900",
+    color: "#4F5A22",
+  },
+  progressTrack: {
+    height: 12,
+    borderRadius: 999,
+    backgroundColor: "rgba(184, 207, 92, 0.22)",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 999,
+    backgroundColor: theme.colors.accentLime,
+  },
+  heroCaption: {
+    fontSize: 14,
+    color: theme.colors.textSoft,
+  },
+  insightChipRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  insightChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: theme.radius.pill,
+    backgroundColor: "rgba(255,255,255,0.7)",
+  },
+  insightChipText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.text,
+  },
+  metricsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  metricCard: {
+    width: "47%",
+    backgroundColor: theme.colors.surface,
     borderRadius: 24,
-    padding: 20,
-    shadowColor: pageColors.charcoal,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
+    padding: 18,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 6,
   },
-  cardHeaderRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 },
-  cardTitle: { fontSize: 20, fontWeight: 'bold', color: pageColors.charcoal },
-  editIcon: { padding: 8, backgroundColor: pageColors.papaya, borderRadius: 20 },
-  
-  streakHeader: { flexDirection: 'row', alignItems: 'center', gap: 16 },
-  streakNumber: { fontSize: 32, fontWeight: '900', color: pageColors.tangerine },
-  streakLabel: { fontSize: 14, color: pageColors.coolSteel, fontWeight: '600' },
-
-  goalRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#f0f0f0' },
-  settingText: { fontSize: 16, color: pageColors.charcoal, fontWeight: '500' },
-  settingSubtext: { fontSize: 12, color: pageColors.coolSteel, marginTop: 4 },
-  goalPercentage: { fontSize: 18, fontWeight: 'bold', color: pageColors.lightGreen },
-  
-  editGoalsButton: { marginTop: 16, paddingVertical: 12, alignItems: 'center', borderRadius: 16, borderWidth: 2, borderColor: pageColors.papaya },
-  editGoalsText: { color: pageColors.charcoal, fontWeight: 'bold', fontSize: 14 },
-
-  milestoneRow: { flexDirection: 'row', alignItems: 'center', gap: 16, marginTop: 16 },
-  iconCircle: { width: 48, height: 48, borderRadius: 24, backgroundColor: pageColors.coolSteel, justifyContent: 'center', alignItems: 'center' },
+  metricValue: {
+    fontSize: 28,
+    lineHeight: 32,
+    fontWeight: "900",
+  },
+  metricLabel: {
+    fontSize: 13,
+    color: theme.colors.textSoft,
+    fontWeight: "700",
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: 26,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: 16,
+  },
+  cardHeaderRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 12,
+  },
+  cardTitle: {
+    fontSize: 21,
+    fontWeight: "900",
+    color: theme.colors.text,
+    flex: 1,
+  },
+  inlineAction: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: theme.radius.pill,
+    backgroundColor: theme.colors.surfaceWarm,
+  },
+  inlineActionText: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: theme.colors.brandDeep,
+  },
+  reliabilityRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  reliabilityMetric: {
+    flex: 1,
+    borderRadius: 20,
+    padding: 16,
+    backgroundColor: theme.colors.backgroundAlt,
+    gap: 8,
+  },
+  reliabilityLabel: {
+    fontSize: 13,
+    color: theme.colors.textSoft,
+    fontWeight: "700",
+  },
+  reliabilityValue: {
+    fontSize: 26,
+    fontWeight: "900",
+    color: theme.colors.text,
+  },
+  cardBodyText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: theme.colors.textSoft,
+  },
+  routeInsightRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  routeInsightBlock: {
+    flex: 1,
+    padding: 16,
+    borderRadius: 20,
+    backgroundColor: theme.colors.backgroundAlt,
+    gap: 6,
+  },
+  routeInsightLabel: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: theme.colors.textSoft,
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  routeInsightValue: {
+    fontSize: 17,
+    lineHeight: 22,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  progressTrackMuted: {
+    height: 10,
+    borderRadius: 999,
+    backgroundColor: "rgba(222,133,88,0.14)",
+    overflow: "hidden",
+  },
+  progressFillMuted: {
+    height: "100%",
+    borderRadius: 999,
+    backgroundColor: theme.colors.brand,
+  },
+  actionStack: { gap: 12 },
+  primaryActionCard: {
+    borderRadius: 22,
+    padding: 18,
+    backgroundColor: theme.colors.brand,
+    gap: 8,
+  },
+  primaryActionEyebrow: {
+    fontSize: 12,
+    fontWeight: "800",
+    color: "rgba(255,255,255,0.82)",
+    textTransform: "uppercase",
+    letterSpacing: 0.8,
+  },
+  primaryActionTitle: {
+    fontSize: 22,
+    lineHeight: 26,
+    fontWeight: "900",
+    color: theme.colors.white,
+  },
+  primaryActionText: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: "rgba(255,255,255,0.86)",
+  },
+  secondaryActionRow: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  secondaryActionCard: {
+    flex: 1,
+    borderRadius: 20,
+    padding: 16,
+    backgroundColor: theme.colors.backgroundAlt,
+    gap: 8,
+  },
+  secondaryActionTitle: {
+    fontSize: 16,
+    fontWeight: "800",
+    color: theme.colors.text,
+  },
+  secondaryActionBody: {
+    fontSize: 13,
+    lineHeight: 18,
+    color: theme.colors.textSoft,
+  },
 });

--- a/apps/mobile/src/screens/StatisticsScreen.tsx
+++ b/apps/mobile/src/screens/StatisticsScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
+import AnimatedWayPointLogo from "../components/AnimatedWayPointLogo";
 import { theme } from "../styles/theme";
 import type {
   StatsSnapshot,
@@ -66,7 +67,12 @@ export default function StatisticsScreen({
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <View style={styles.pageHeaderRow}>
           <View style={styles.titleBlock}>
-            <Text style={styles.pageHeader}>Trail Stats</Text>
+            <View style={styles.headerTitleRow}>
+              <View style={styles.headerLogoWrap}>
+                <AnimatedWayPointLogo size={70} />
+              </View>
+              <Text style={styles.pageHeader}>Stats</Text>
+            </View>
             <Text style={styles.pageSubheader}>
               A quick read on momentum, safety habits, and what to do next.
             </Text>
@@ -221,6 +227,17 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   titleBlock: { flex: 1, gap: 6 },
+  headerTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  headerLogoWrap: {
+    width: 62,
+    height: 62,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   pageHeader: {
     fontSize: 34,
     lineHeight: 38,

--- a/apps/mobile/src/types/appData.ts
+++ b/apps/mobile/src/types/appData.ts
@@ -1,0 +1,41 @@
+export type TrustedContact = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  note: string;
+};
+
+export type UserProfile = {
+  firstName: string;
+  lastName: string;
+  headline: string;
+  bio: string;
+  city: string;
+  privacyLabel: string;
+  memberSince: string;
+  nextMilestone: string;
+};
+
+export type UserSettings = {
+  autoShareLocation: boolean;
+  pushNotifications: boolean;
+  routeDeviationAlerts: boolean;
+  missedCheckInAlerts: boolean;
+  weeklyDigest: boolean;
+  locationVisibility: "private" | "trusted contacts" | "during journey";
+  defaultJourneyMode: "solo" | "group";
+};
+
+export type StatsSnapshot = {
+  milesThisWeek: number;
+  weeklyGoalMiles: number;
+  safeJourneys: number;
+  hoursOutside: number;
+  currentStreakDays: number;
+  completionRate: number;
+  checkInRate: number;
+  favoriteRouteTitle: string;
+  lastJourneyLabel: string;
+  nextGoalLabel: string;
+};


### PR DESCRIPTION
Description:

**Objective**  
This PR refreshes the mobile app experience by redesigning the stats, profile, and settings screens, improving navigation behavior, and tightening branding consistency across the main user flows.

**Changes Made**

- Reworked the `Stats`, `Profile`, and `Settings` screens with a more polished layout, stronger visual hierarchy, and better-connected app flows.
- Added shared mobile app data types for profile, settings, trusted contacts, and stats in `apps/mobile/src/types/appData.ts`.
- Updated `AppNavigator` so these screens use shared state instead of isolated placeholder content.
- Connected `StartJourney` to shared trusted-contact and default journey-mode data.
- Updated journey completion flow so completed trips roll into the stats snapshot.
- Refined the bottom nav center button so it shows `Home` and returns to the home page from non-home screens.
- Updated the active journey screen’s center home button to use the same green treatment as the other home-return states.
- Restored and enlarged the animated WayPoint logo in the home header.
- Added animated WayPoint logo branding to the headers for `Routes`, `Stats`, `Profile`, and `Settings`.
- Tightened header spacing so page branding feels more consistent across the app.
- Removed the `Explore` eyebrow from the routes screen for a cleaner header.

**Files Touched**

- `apps/mobile/src/navigation/AppNavigator.tsx`
- `apps/mobile/src/components/NavBar.tsx`
- `apps/mobile/src/screens/HomeScreen.tsx`
- `apps/mobile/src/screens/RoutesScreen.tsx`
- `apps/mobile/src/screens/StatisticsScreen.tsx`
- `apps/mobile/src/screens/ProfileScreen.tsx`
- `apps/mobile/src/screens/SettingsScreen.tsx`
- `apps/mobile/src/screens/StartJourneyScreen.tsx`
- `apps/mobile/src/types/appData.ts`